### PR TITLE
Fix catastrophic cancellation in getP2

### DIFF
--- a/puffin/lib/utilities/gamma_to_p2.f90
+++ b/puffin/lib/utilities/gamma_to_p2.f90
@@ -13,7 +13,7 @@
 
 module gtop2
 
-use puffin_kinds, only: WP
+use puffin_kinds, only: WP, IP
 
 implicit none (type, external)
 private
@@ -84,7 +84,8 @@ contains
 
 !            LOCAL
 
-    real(kind=wp), allocatable :: u(:), rt(:)
+    integer(kind=ip) :: i
+    real(kind=wp) :: u, rt
 
 ! Computed via the algebraically-equivalent but numerically-stable form.
 ! Writing this as (1/sqrt(1-u) - 1)/eta subtracts two quantities both very
@@ -93,18 +94,23 @@ contains
 ! (1 - sqrt(1-u)) * (1 + sqrt(1-u)) = u, the same value is
 ! u / (sqrt(1-u) * (1 + sqrt(1-u))), which has no cancellation: u itself is
 ! a sum of positive terms.
+!
+! Written as an explicit !$OMP DO over private scalars rather than array
+! expressions in a WORKSHARE. getP2 is called from inside the !$OMP PARALLEL
+! region in getrhs, where any local array temporary would be thread-private:
+! a WORKSHARE would then have each thread fill only its own slice of its own
+! copy and read the rest uninitialised. Only p2 -- a dummy argument, and so
+! shared -- may be written across a worksharing construct here.
 
-    allocate(u(size(p2)), rt(size(p2)))
+!$OMP DO PRIVATE(u, rt)
 
-!$OMP WORKSHARE
+    do i = 1, size(p2, kind=ip)
+      u = ( 1.0_wp + aw**2*(px(i)**2 + py(i)**2) ) / (gamma0**2 * gamma(i)**2)
+      rt = sqrt(1.0_wp - u)
+      p2(i) = u / (eta * rt * (1.0_wp + rt))
+    end do
 
-    u = ( 1.0_wp + aw**2*(px**2 + py**2) ) / (gamma0**2 * gamma**2)
-    rt = sqrt(1.0_wp - u)
-    p2 = u / (eta * rt * (1.0_wp + rt))
-
-!$OMP END WORKSHARE
-
-    deallocate(u, rt)
+!$OMP END DO
 
   end subroutine getP2
 

--- a/puffin/lib/utilities/gamma_to_p2.f90
+++ b/puffin/lib/utilities/gamma_to_p2.f90
@@ -82,13 +82,29 @@ contains
 
     real(kind=wp), contiguous, intent(out) :: p2(:)
 
+!            LOCAL
+
+    real(kind=wp), allocatable :: u(:), rt(:)
+
+! Computed via the algebraically-equivalent but numerically-stable form.
+! Writing this as (1/sqrt(1-u) - 1)/eta subtracts two quantities both very
+! close to 1 to produce a result of order u/2 ~ 1e-8, losing ~8 significant
+! digits before the division by eta (~1e-8) scales it back up. Since
+! (1 - sqrt(1-u)) * (1 + sqrt(1-u)) = u, the same value is
+! u / (sqrt(1-u) * (1 + sqrt(1-u))), which has no cancellation: u itself is
+! a sum of positive terms.
+
+    allocate(u(size(p2)), rt(size(p2)))
 
 !$OMP WORKSHARE
 
-    p2 = (( 1_wp/sqrt(1_wp - 1_wp / (gamma0**2 * gamma**2) * ( 1 + &
-             aw**2*(px**2 + py**2))))-1_wp) / eta
+    u = ( 1.0_wp + aw**2*(px**2 + py**2) ) / (gamma0**2 * gamma**2)
+    rt = sqrt(1.0_wp - u)
+    p2 = u / (eta * rt * (1.0_wp + rt))
 
 !$OMP END WORKSHARE
+
+    deallocate(u, rt)
 
   end subroutine getP2
 


### PR DESCRIPTION
Fixes a catastrophic cancellation in `getP2`, which computes `p2` = `dz2/dz`.
This is the root cause of the macOS/ARM vs Linux/x86 divergence tracked in #118
(see [this comment](https://github.com/UKFELs/Puffin/issues/118#issuecomment-5363033227)
for the full investigation), but it is a correctness problem in its own right
and is not specific to that test.

## The problem

`puffin/lib/utilities/gamma_to_p2.f90` computed

```fortran
p2 = (( 1_wp/sqrt(1_wp - 1_wp / (gamma0**2 * gamma**2) * ( 1 + &
         aw**2*(px**2 + py**2))))-1_wp) / eta
```

With `u = (1 + aw^2*p_perp^2) / (gamma0^2 * gamma^2)`, the numerator
`1/sqrt(1-u) - 1` is approximately `u/2`, but is formed by **subtracting two
quantities both very close to 1**. For a typical deck (`gamma0 = 8000`,
`aw = 1.414216`) `u ~ 4e-8`, so the numerator is ~2e-8 carrying ~1 ulp of 1 as
absolute error — a relative error of ~1e-8, which the division by `eta` (~1.6e-8)
preserves while scaling the value back to O(1).

Checked against a 60-digit reference, for one macroparticle from the
`osc-linear-taper` deck:

```
reference              1.3222161754044388
as written (double)    1.3222161783232877   rel err = 2.21e-09
stable form (double)   1.3222161754044386   rel err = 1.68e-16
```

**13 million ulp.** `dz2/dz` carried roughly 8 correct significant digits, for
every macroparticle, in every run.

## The fix

Since `(1 - sqrt(1-u)) * (1 + sqrt(1-u)) = u`, the same quantity is
`u / (sqrt(1-u) * (1 + sqrt(1-u)))` — no cancellation, since `u` is a sum of
positive terms. That form is accurate to 1 ulp.

## Why it caused the #118 platform split

The old expression contained `1 - a*b`, an FMA contraction site. Whether a given
macroparticle landed above or below the error floor depended on whether the
compiler fused that multiply-add — and `fmadd` is baseline aarch64 while FMA3 is
not baseline x86-64, so macOS fused and CI did not.

Measured with contraction on/off on a single machine (so the platform is not a
variable), max field difference relative to peak:

| deck | steps | before | after |
| --- | ---: | ---: | ---: |
| `f1main` (1D) | 30 | 9.59e-14 | **4.27e-14** |
| `clara_test` (3D) | 150 | 1.98e-12 | **2.69e-14** |
| `osc_taper` (parked, #118) | 4350 | 1.08e-09 | **1.14e-11** |

## Effect on existing goldens

Same build, fixed vs unfixed:

| deck | change |
| --- | ---: |
| `f1main` | 7.18e-13 rel — 2.8e-14 absolute |
| `clara_test` | 3.03e-10 rel — 3.8e-13 absolute |
| `osc_taper` | 2.75e-05 rel |

Both active e2e tests move far inside the 1e-10 absolute field tolerance, so
**no golden files need regenerating for this PR**. The parked `osc_taper`
reference in `test/sinbin/` moves by 2.75e-05 and would need regenerating when
that test is revived — it needs that anyway.

## Testing

The pFUnit suite has now been run locally against this branch (pFUnit 4.19, the
same version CI uses), at several thread counts:

| `OMP_NUM_THREADS` | result |
| ---: | --- |
| 1 | 3/3 passed |
| 2 | 3/3 passed |
| 4 | 3/3 passed |

The thread sweep matters here: the first commit on this branch had an OpenMP
correctness bug that only manifests above one thread, and it passed the suite at
`OMP_NUM_THREADS=1`. As a check on the local setup, the suite was also built and
run against that broken commit (001f510) in a worktree — it passes at 1 thread
and fails `puffin_e2e_tests` at 4, reproducing the CI failure exactly. So a green
local run on this branch is now meaningful rather than vacuous.

Numerical verification, contraction on/off on a single machine at 4 threads:

| check | result |
| --- | --- |
| `f1main`, 1 vs 4 threads | 1.39e-17 absolute |
| `clara_test`, 1 vs 4 threads | 2.06e-17 absolute |
| FP exceptions across all runs | none |
| `osc_taper` contraction on/off | 1.137e-11 relative to peak |

## Not addressed here

- The divergence on `osc_taper` is reduced 95x but not eliminated (1.14e-11
  remains), so at least one more sensitive site exists. `getP2` was the dominant
  term, not the only one.
- Reviving the parked `osc_taper` test (#118). With this fix every dataset it
  checks clears its existing tolerance, so no tolerance change is needed —
  only a regenerated reference. Measured with contraction on/off as the
  cross-platform proxy: `power` / `powerSI` / `Intensity` 1.01e-11,
  `bunching2ndHarmonic` 1.57e-12, `bunchingFundamental` 2.31e-12,
  `beamCurrent` 1.41e-14, `meanGamma` 2.22e-16, `Slice Charge` 0, all against
  a 1e-10 tolerance; field 8.86e-14 against 1e-10 absolute.
- A latent reproducibility bug found along the way: in `undulator.f90` the
  diffraction step propagates as one combined half-step when not writing, and as
  two separate calls when it is, so `iWriteNthSteps` changes results in 3D.
  Inert in 1D. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZVEVM3jMx2u2kdGawZuPV
