### PR TITLE
Document dev as the base branch for development

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,22 @@
 
 Fortran FEL (Free Electron Laser) simulation code.
 
+## Git workflow
+
+`dev` is the base branch, both here (`origin`, mightylorenzo/Puffin) and
+upstream (`upstream`, UKFELs/Puffin). Always sync from and branch off `dev`:
+
+```
+git fetch upstream
+git checkout dev
+git merge upstream/dev    # or: git rebase upstream/dev
+git checkout -b my-feature
+```
+
+Open pull requests against `dev`, never `master`. `master` upstream is only
+updated by periodic merges from `dev` at release points, so do not branch off
+it, target it, or sync to it for normal work.
+
 ## Build & Test
 
 - Build: `make -j4 -C build/`

--- a/README.md
+++ b/README.md
@@ -58,6 +58,39 @@ mpirun -np 2 puffin clara.in
 ```
 to run the CLARA example on 2 MPI processes.
 
+## Contributing
+
+`dev` is the base branch for development, on both the upstream
+[UKFELs/Puffin](https://github.com/UKFELs/Puffin) repository and its forks.
+`master` is only updated by periodic merges from `dev` at release points, so
+it lags behind and should not be used as a starting point for new work.
+
+To contribute:
+
+1. Fork the repository, and add the upstream repo as a remote:
+   ```
+   git remote add upstream https://github.com/UKFELs/Puffin.git
+   ```
+2. Sync your `dev` branch with upstream before starting:
+   ```
+   git fetch upstream
+   git checkout dev
+   git merge upstream/dev
+   ```
+3. Create your topic branch off `dev`:
+   ```
+   git checkout -b my-feature
+   ```
+4. Make your changes, and check that the test suites still pass:
+   ```
+   ctest --output-on-failure --test-dir build/
+   ```
+5. Push the branch to your fork and open a pull request **against `dev`**,
+   not `master`.
+
+Keep your branch up to date by merging (or rebasing on) `upstream/dev` rather
+than `upstream/master`.
+
 ## Release Notes
 
 1.9.0


### PR DESCRIPTION
Records the switch to `dev` as the base branch for development, on both this repository and forks. `master` is only updated by periodic merges from `dev` at release points, so it should not be used as a starting point for new work or as a PR target.

- `CLAUDE.md`: new **Git workflow** section — sync from and branch off `dev`, open PRs against `dev`, never `master`.
- `README.md`: new **Contributing** section between "How to run" and "Release Notes" — fork, add the upstream remote, sync `dev`, branch off it, run `ctest`, and open the PR against `dev`.

Documentation only; no code or build changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)