### PR TITLE
Fix out-of-bounds z2base read that makes FEL gain depend on MPI rank count

### DIFF
--- a/puffin/lib/macroparticle_generation/simple_electron_gen.f90
+++ b/puffin/lib/macroparticle_generation/simple_electron_gen.f90
@@ -622,7 +622,15 @@ SUBROUTINE genBeam(iNMP, iNMP_loc, sigE, alphax, betax, alphay, betay, &
 
       gamseq = gamseq + offsets(iGam_CG)
 
-      z2seq = (z2seq - 0.5_wp) * (z2base(2) - z2base(1))
+!   Spread the sequence over one z2 slice. Use the grid spacing rather than
+!   z2base(2)-z2base(1): with few z2 macroparticles and many MPI ranks a rank
+!   can hold a single z2 slice, and z2base(2) is then out of bounds.
+
+      if (iNMP_loc(iZ2_CG) > 0_ip) then
+        z2seq = (z2seq - 0.5_wp) * (sz2_grid(2) - sz2_grid(1))
+      else
+        z2seq = 0.0_wp
+      end if
 
 !   Rotate phase space to Twiss params...
 
@@ -675,7 +683,8 @@ SUBROUTINE genBeam(iNMP, iNMP_loc, sigE, alphax, betax, alphay, betay, &
       deallocate(nktemp, z2base)
 
       ! add noise in z2
-      if (q_noise) call applyNoise(z2_tmpcoord, sz2_grid(2) - sz2_grid(1), s_tmp_macro)
+      if (q_noise .and. (iNMP_loc(iZ2_CG) > 0_ip)) &
+        call applyNoise(z2_tmpcoord, sz2_grid(2) - sz2_grid(1), s_tmp_macro)
 
   end if
 


### PR DESCRIPTION
Fixes #123.

## The bug

`simple_electron_gen.f90:625`, in `genBeam`, in the `nseqparts` (non-`qEquiXY_G`) loading path:

```fortran
z2seq = (z2seq - 0.5_wp) * (z2base(2) - z2base(1))
```

`z2base` is allocated with size `iNMP_loc(iZ2_CG)` — the number of z2 macroparticle slices *this rank* holds after `splitBeams`. The expression is meant to spread the sequence over one slice width, but it reads `z2base(2)` unconditionally, which is out of bounds as soon as a rank ends up with a single slice.

The single-slice CLARA example has `iNumMPs(z2) = 4`:

| ranks | slices per rank | `z2base(2)` |
|---|---|---|
| 1 | 4 | in bounds |
| 2 | 2, 2 | in bounds |
| 3 | 2, 1, 1 | **out of bounds on ranks 1, 2** |
| 4 | 1, 1, 1, 1 | **out of bounds everywhere** |
| 6 | 1, 1, 1, 1, 0, 0 | **out of bounds everywhere** |

Ranks 4 and 5 at `npes=6` get zero slices, so `sz2_grid(2)` in the `applyNoise` call below is out of bounds on those ranks too.

## Effect

The garbage scale factor scatters the quiet-start macroparticles in z2 and destroys the loading. Initial bunching at `zTotal = 0`:

| ranks | 1 | 2 | 3 | 4 | 6 |
|---|---|---|---|---|---|
| \|b₀\| | 4.6e-4 | 7.8e-4 | **0.217** | **0.204** | **0.204** |

1–2 ranks is shot noise (1/√N_e ≈ 1.1e-3 for this charge). At ≥3 ranks the beam starts ~20% pre-bunched, which acts as a large spurious coherent seed — so the reported "gain" at ≥3 ranks in #123 is superradiant emission from an artificially bunched beam, and the flat 1–2 rank result was the correct one.

## Fix

Use the grid spacing. `sz2_grid` holds `iNMP_loc(iZ2_CG) + 1` edges, so `sz2_grid(2) - sz2_grid(1)` is the same quantity and is valid whenever the rank holds at least one slice. This is what the dist-file loader already does with its own `dz2` (`MPfDists.f90:428`), and what the `applyNoise` call a few lines below already used. Both are guarded against ranks holding no slices.

## Verification

Initial loading is uniform at every rank count after the fix (\|b₀\| = 2.3e-4 to 1.0e-3, flat z2 histogram), and the gain no longer depends on rank count. Per-period max of `mean(powerSI)`, single-slice CLARA, first three modules:

```
ranks=1 : P(z=0.275)=3.831e+04   P(z=0.550)=3.590e+04
ranks=2 : P(z=0.275)=3.836e+04   P(z=0.550)=3.637e+04
ranks=3 : P(z=0.275)=3.897e+04   P(z=0.550)=3.744e+04
ranks=4 : P(z=0.275)=3.904e+04   P(z=0.550)=3.730e+04
ranks=6 : P(z=0.275)=3.845e+04   P(z=0.550)=3.618e+04
```

against 3.8e+04 (2 ranks) versus 9.1e+06 (6 ranks) at z = 0.550 m before. Residual spread is within the run-to-run SASE scatter for this deck.

All four tests pass on this branch in a clean build directory:

```
1/4 puffin_basic_tests .......... Passed
2/4 puffin_e2e_tests ............ Passed
3/4 puffin_e2e_tests_1d_taper ... Passed
4/4 puffin_e2e_tests_3d ......... Passed
100% tests passed out of 4
```

The 1D decks are unaffected by construction: `read_base_input.f90:546` sets `qEquiXY_G = .true.` for `qOneD` with a single gamma MP, so they never reach the changed branch. Confirmed empirically — `f1main` outputs are bit-identical with and without the patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmMWygCaR5R5mAoGmZX6VM
