### PR TITLE
Interactive field viewers: theming, playback, unit toggle, and mesh-aware reductions

### DIFF
--- a/utilities/pyPlotting/puffin_viz_data.py
+++ b/utilities/pyPlotting/puffin_viz_data.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Shared data reduction for the Puffin field viewers.
+
+Kept apart from puffin_viz_theme (look) and puffin_viz_player (behaviour):
+this is about turning what Puffin wrote into the number a plot should show,
+and getting it wrong is a correctness bug rather than a cosmetic one.
+"""
+
+import numpy as np
+
+C0 = 2.99792458e8
+
+# puffin/lib/deriv_globals.f90
+#   integer(kind=ip), parameter :: iTemporal = 0_ip
+#   integer(kind=ip), parameter :: iPeriodic = 1_ip
+I_TEMPORAL = 0
+I_PERIODIC = 1
+
+
+def mesh_is_periodic(attrs):
+    """True if this run used the periodic (single radiation period) mesh.
+
+    Falls back to periodic when the attribute is absent, which is what the
+    viewers assumed before `fieldMesh` was consulted at all.
+    """
+    return int(attrs.get('fieldMesh', I_PERIODIC)) == I_PERIODIC
+
+
+def reduce_power(power, attrs):
+    """Collapse a powerSI array over z2 to one number for the power-vs-z curve.
+
+    The right reduction depends on what the z2 window *is*:
+
+    periodic mesh — the window is exactly one radiation period, so the mean
+        over it is a genuine cycle average and is the quantity wanted.
+
+    temporal mesh — the window is a chunk of ct-z holding a pulse that fills
+        only part of it (24% in the PhyOfPlasmas fig7a example). The mean then
+        divides by however much empty window the deck happened to allocate, so
+        it is not a property of the radiation at all — halve sFModelLengthZ2
+        and the "power" doubles. Peak power is the standard pulse quantity and
+        is independent of the window, so use that. In fig7a the two differ by
+        4.6x.
+
+    Returns (value, label) so the caller can title the axis with the
+    reduction actually applied rather than leaving the reader to guess.
+    """
+    p = np.asarray(power, dtype=float)
+    if p.size == 0:
+        return 0.0, 'power'
+    if mesh_is_periodic(attrs):
+        return float(np.mean(p)), 'mean power (cycle avg)'
+    return float(np.max(p)), 'peak power'
+
+
+def power_axis_label(attrs):
+    """Y-axis label matching the reduction reduce_power() will apply."""
+    return ('Mean power (W)' if mesh_is_periodic(attrs)
+            else 'Peak power (W)')
+
+
+def power_title(attrs):
+    return ('Power vs z  (cycle-averaged)' if mesh_is_periodic(attrs)
+            else 'Peak power vs z')
+
+
+# ── energy ───────────────────────────────────────────────────────────────────
+
+def dt_per_node(attrs):
+    """Time step between z2 nodes, in seconds.
+
+    z2 is a length (ct - z) in scaled units, so the physical node spacing is
+    sLengthOfElmZ2 * Lc metres and the light-transit time across it is that
+    over c.
+    """
+    return float(attrs['sLengthOfElmZ2']) * float(attrs['Lc']) / C0
+
+
+def pulse_energy(power, attrs):
+    """Radiated energy in J: the integral of P dt across the z2 window.
+
+    Unlike peak power this is an extensive quantity, so it answers a
+    different question — peak power says how intense the spike is, energy
+    says how much light there is in total. Neither substitutes for the
+    other, which is why they get their own plots rather than two y-axes.
+
+    On a periodic mesh the window is one radiation period, so this is the
+    energy per period rather than a pulse energy; energy_title() says which.
+    """
+    p = np.asarray(power, dtype=float)
+    if p.size == 0:
+        return 0.0
+    return float(np.sum(p) * dt_per_node(attrs))
+
+
+def energy_axis_label(attrs):
+    return ('Energy per period (J)' if mesh_is_periodic(attrs)
+            else 'Pulse energy (J)')
+
+
+def energy_title(attrs):
+    return ('Energy vs z  (per radiation period)' if mesh_is_periodic(attrs)
+            else 'Pulse energy vs z')
+
+
+# ── temporal profile ─────────────────────────────────────────────────────────
+
+def mesh_bounds(h5file, group='intFieldMeshSI'):
+    """(lower, upper) bounds in metres from a Vs mesh group, or None."""
+    g = h5file.get(group)
+    if g is None:
+        return None
+    lo = g.attrs.get('vsLowerBounds')
+    hi = g.attrs.get('vsUpperBounds')
+    return None if lo is None or hi is None else (lo, hi)
+
+
+# ── unit systems ─────────────────────────────────────────────────────────────
+
+SCALED, SI = 0, 1
+
+
+class Units:
+    """Conversion factors and axis labels for one unit system.
+
+    Puffin works in scaled variables and writes most quantities twice, once
+    scaled and once in SI (power/powerSI, Intensity/IntensitySI,
+    beamCurrent/beamCurrentSI), so where a scaled dataset exists this picks
+    it rather than converting.
+
+    Each `*_mul` converts from the form the viewers hold internally to the
+    displayed one. Those internal forms differ per quantity, so they are
+    named here rather than left implicit:
+
+        z          metres (zTotal, as written)
+        z2         scaled (node index x sLengthOfElmZ2)
+        x, y       scaled (node offset x sLengthOfElmX)
+        intensity  |A_perp|^2
+    """
+
+    def __init__(self, attrs, mode=SI):
+        self.mode = mode
+        self.scaled = (mode == SCALED)
+        Lg = float(attrs['Lg'])
+        Lc = float(attrs['Lc'])
+        self.Lg, self.Lc = Lg, Lc
+        self.trans = np.sqrt(Lg * Lc)      # scaled transverse -> metres
+
+        if self.scaled:
+            self.z_mul,  self.z_label  = 1.0 / Lg, 'z̄'
+            self.z2_mul, self.z2_label = 1.0,      'z₂'
+            self.z2_unit               = ''      # scaled: dimensionless
+            self.xy_mul                = 1.0
+            self.x_label, self.y_label = 'x̄', 'ȳ'
+            self.intens_mul            = 1.0
+            self.intens_label          = '|A⊥|²'
+            self.power_key,  self.power_label  = 'power',       'Power (scaled)'
+            self.curr_key,   self.curr_label   = 'beamCurrent', 'Current (scaled)'
+            self.energy_label                  = 'Energy (scaled)'
+        else:
+            self.z_mul,  self.z_label  = 1.0,          'z (m)'
+            self.z2_mul, self.z2_label = Lc * 1e6,     'ct − z  (µm)'
+            self.z2_unit               = 'µm'
+            self.xy_mul                = self.trans * 1e3
+            self.x_label, self.y_label = 'x (mm)', 'y (mm)'
+            self.intens_mul            = None      # caller supplies intens_scale
+            self.intens_label          = 'Intensity  (W m⁻²)'
+            self.power_key,  self.power_label  = 'powerSI',       'Power (W)'
+            self.curr_key,   self.curr_label   = 'beamCurrentSI', 'Current (A)'
+            self.energy_label                  = 'Pulse energy (J)'
+
+    def intensity_factor(self, iscale):
+        """|A|^2 -> displayed intensity."""
+        return 1.0 if self.scaled else iscale
+
+    def energy(self, power, attrs):
+        """Energy for the *displayed* power units.
+
+        In SI this is joules; scaled it is the same integral in scaled
+        variables, which is why the label just says "scaled" rather than
+        naming a unit it does not have.
+        """
+        p = np.asarray(power, dtype=float)
+        if p.size == 0:
+            return 0.0
+        if self.scaled:
+            return float(np.sum(p) * float(attrs['sLengthOfElmZ2']))
+        return float(np.sum(p) * dt_per_node(attrs))
+
+    def z2_axis(self, n, attrs, bounds=None):
+        """ct-z / z2 axis in the displayed units."""
+        base = np.arange(n) * float(attrs['sLengthOfElmZ2'])
+        if self.scaled or bounds is None or None in bounds:
+            return base * self.z2_mul
+        lo, hi = bounds
+        return np.linspace(float(lo) * 1e6, float(hi) * 1e6, n)
+
+    def power_title(self, attrs):
+        which = ('Mean power' if mesh_is_periodic(attrs) else 'Peak power')
+        return f'{which} vs {"z̄" if self.scaled else "z"}'
+
+    def energy_title(self, attrs):
+        which = ('Energy per period' if mesh_is_periodic(attrs)
+                 else 'Pulse energy')
+        return f'{which} vs {"z̄" if self.scaled else "z"}'

--- a/utilities/pyPlotting/puffin_viz_player.py
+++ b/utilities/pyPlotting/puffin_viz_player.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Playback controls for the Bokeh field viewers.
+
+Drives an existing Slider on a timer so a run animates instead of being
+scrubbed by hand. Two groups of controls:
+
+    |◄  ► Play  ►|        transport — step back, play/pause, step forward
+    −  4 fps  +           speed
+
+The arrows belong to frame stepping rather than to speed: ◄◄/►► read as
+rewind and fast-forward, which is what a reader would expect them to do to
+the *position*, not to the rate. Speed gets −/+ beside its readout, where
+there is nothing to misread.
+
+Kept separate from puffin_viz_theme (which is only about how things look)
+so both viewers share one implementation of the behaviour.
+"""
+
+from bokeh.models import Button, Div, InlineStyleSheet
+from bokeh.layouts import row
+
+import puffin_viz_theme as pvt
+
+# Frames per second. The server side of a step is cheap (~16 ms for the 1D
+# viewer, ~1 ms for 3D); what actually limits the top end is pushing a
+# ~10^5-point phase-space scatter over the websocket and drawing it, so the
+# ladder stops at 16 and the default sits mid-range.
+SPEEDS = [0.5, 1.0, 2.0, 4.0, 8.0, 16.0]
+DEFAULT_SPEED = 3          # → 4 fps
+
+
+def _btn_css(t, accent=False):
+    """Button chrome from the theme tokens, so dark mode carries too."""
+    bg     = t['field'] if accent else t['surface']
+    fg     = '#ffffff'   if accent else t['ink2']
+    border = t['field'] if accent else t['axis']
+    hover  = t['field'] if accent else t['grid']
+    return InlineStyleSheet(css=f"""
+      .bk-btn {{
+        background: {bg};
+        color: {fg};
+        border: 1px solid {border};
+        border-radius: 6px;
+        font-family: {pvt.FONT};
+        font-size: 12px;
+        font-weight: 500;
+        padding: 5px 12px;
+        transition: background 120ms ease, color 120ms ease;
+      }}
+      .bk-btn:hover {{ background: {hover}; color: {t['ink'] if not accent else '#ffffff'}; }}
+      .bk-btn:disabled {{ opacity: .4; }}
+    """)
+
+
+class Player:
+    """Timer-driven playback bound to `slider`.
+
+    Looping is deliberate: for a demo you want the gain curve to run round
+    again rather than stopping dead on the last dump.
+    """
+
+    def __init__(self, doc, slider, n_steps, t):
+        self.doc, self.slider, self.n, self.t = doc, slider, n_steps, t
+        self.i_speed = DEFAULT_SPEED
+        self.cb = None
+        self._programmatic = False
+
+        self._css_idle   = _btn_css(t, accent=False)
+        self._css_accent = _btn_css(t, accent=True)
+
+        self.b_back = Button(label='|◄', width=46, stylesheets=[self._css_idle])
+        self.b_play = Button(label='► Play', width=92,
+                             stylesheets=[self._css_accent])
+        self.b_fwd  = Button(label='►|', width=46, stylesheets=[self._css_idle])
+        self.b_slow = Button(label='−', width=40, stylesheets=[self._css_idle])
+        self.b_fast = Button(label='+', width=40, stylesheets=[self._css_idle])
+        self.readout = Div(text=self._speed_html(), width=64,
+                           margin=(9, 0, 0, 0))
+
+        self.b_back.on_click(lambda: self._step(-1))
+        self.b_play.on_click(self.toggle)
+        self.b_fwd.on_click(lambda: self._step(+1))
+        self.b_slow.on_click(lambda: self._nudge(-1))
+        self.b_fast.on_click(lambda: self._nudge(+1))
+
+        # Grabbing the slider by hand should take over from the timer rather
+        # than fight it. Programmatic ticks set a flag so they don't self-pause.
+        slider.on_change('value', self._on_slider)
+
+        self._live = n_steps >= 2           # a single dump has nothing to animate
+        for b in (self.b_play, self.b_back, self.b_fwd):
+            b.disabled = not self._live
+        self._sync_speed_buttons()
+
+    # ── widgets ──────────────────────────────────────────────────────────
+    def layout(self, inset=0, top=0, bottom=6):
+        # Transport group, then a gap, then the speed group — so the two
+        # jobs read as two clusters rather than one undifferentiated strip.
+        self.b_slow.margin = (0, 0, 0, 26)
+        return row(self.b_back, self.b_play, self.b_fwd,
+                   self.b_slow, self.readout, self.b_fast,
+                   spacing=6, margin=(top, 10, bottom, inset))
+
+    def _speed_html(self):
+        fps = SPEEDS[self.i_speed]
+        txt = f'{fps:g} fps'
+        return (f'<span style="font-family:{pvt.FONT}; font-size:12px; '
+                f'color:{self.t["ink2"]}; font-variant-numeric:tabular-nums;">'
+                f'{txt}</span>')
+
+    def _sync_speed_buttons(self):
+        # Must respect _live too: this runs after the initial disable, so
+        # without the guard it would re-enable the speed buttons on a
+        # single-dump run where there is nothing to play.
+        self.b_slow.disabled = not self._live or self.i_speed == 0
+        self.b_fast.disabled = not self._live or self.i_speed == len(SPEEDS) - 1
+
+    # ── playback ─────────────────────────────────────────────────────────
+    def _period_ms(self):
+        return 1000.0 / SPEEDS[self.i_speed]
+
+    def _tick(self):
+        nxt = self.slider.value + 1
+        self._programmatic = True
+        try:
+            self.slider.value = 0 if nxt >= self.n else nxt   # loop
+        finally:
+            self._programmatic = False
+
+    def _step(self, d):
+        """Move one frame, wrapping at either end.
+
+        Deliberately not flagged as programmatic: stepping by hand is manual
+        interaction, so it drops out of playback via _on_slider, exactly as
+        dragging the slider does.
+        """
+        if not self._live:
+            return
+        self.slider.value = (self.slider.value + d) % self.n
+
+    def _on_slider(self, attr, old, new):
+        if self.playing and not self._programmatic:
+            self.stop()
+
+    @property
+    def playing(self):
+        return self.cb is not None
+
+    def start(self):
+        if self.playing or self.n < 2:
+            return
+        # Parked on the last frame: restart from the top rather than
+        # immediately wrapping.
+        if self.slider.value >= self.n - 1:
+            self._programmatic = True
+            try:
+                self.slider.value = 0
+            finally:
+                self._programmatic = False
+        self.cb = self.doc.add_periodic_callback(self._tick, self._period_ms())
+        self.b_play.label = '❚❚ Pause'
+        self.b_play.stylesheets = [self._css_idle]
+
+    def stop(self):
+        if not self.playing:
+            return
+        self.doc.remove_periodic_callback(self.cb)
+        self.cb = None
+        self.b_play.label = '► Play'
+        self.b_play.stylesheets = [self._css_accent]
+
+    def toggle(self):
+        self.stop() if self.playing else self.start()
+
+    def _nudge(self, d):
+        i = min(max(self.i_speed + d, 0), len(SPEEDS) - 1)
+        if i == self.i_speed:
+            return
+        self.i_speed = i
+        self.readout.text = self._speed_html()
+        self._sync_speed_buttons()
+        if self.playing:            # re-arm the timer at the new period
+            self.doc.remove_periodic_callback(self.cb)
+            self.cb = self.doc.add_periodic_callback(self._tick,
+                                                     self._period_ms())

--- a/utilities/pyPlotting/puffin_viz_theme.py
+++ b/utilities/pyPlotting/puffin_viz_theme.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Shared visual theme for the Puffin field viewers.
+
+One place for the palette, fonts and chrome so viewField1D_bokeh.py,
+viewField3D_bokeh.py and viewField3D.py read as a single family.
+
+Colour is assigned by the job it does, not by panel order:
+
+    field   — optical / radiation quantities (intensity, spectrum, power)
+    beam    — electron-beam quantities (current, phase space)
+    select  — the interactive range window (a control, not data)
+    drift   — lattice drift space: absence of an element, so it recedes
+              into the chrome grey rather than taking a hue
+
+So a colour means the same thing in every panel: blue is light, orange is
+electrons. The three hues are the first three slots of the reference
+categorical palette, which are the slots that clear the all-pairs
+colour-vision gates. Validated with the skill's validator in both modes:
+
+    light  worst all-pairs CVD ΔE 9.2 (deutan), normal-vision ΔE 24.0
+    dark   worst all-pairs CVD ΔE 9.4 (deutan), normal-vision ΔE 20.9
+
+Light-mode aqua sits at 2.74:1 against the surface, below the 3:1 line.
+That is a documented relief case and is discharged here by the lattice
+legend: every element type carries a visible text label, so identity never
+rests on colour alone.
+
+Set PUFFIN_VIZ_THEME=dark for the dark surface. The dark column is the
+same hues re-stepped for a dark background, not an automatic inversion.
+"""
+
+import os
+
+FONT = 'system-ui, -apple-system, "Segoe UI", sans-serif'
+
+_LIGHT = dict(
+    mode='light',
+    surface='#fcfcfb',   # chart surface
+    page='#f9f9f7',      # page plane behind the charts
+    ink='#0b0b0b',       # primary text
+    ink2='#52514e',      # secondary text
+    muted='#898781',     # axis / tick labels
+    grid='#e1e0d9',      # hairline gridline
+    axis='#c3c2b7',      # baseline / axis line
+    field='#2a78d6',     # slot 1 blue   — radiation
+    beam='#eb6834',      # slot 2 orange — electrons
+    select='#1baf7a',    # slot 3 aqua   — range-selection window
+    drift='#c3c2b7',     # lattice drift: chrome, not a series
+    marker='#0b0b0b',    # current-z cue
+)
+
+_DARK = dict(
+    mode='dark',
+    surface='#1a1a19',
+    page='#0d0d0d',
+    ink='#ffffff',
+    ink2='#c3c2b7',
+    muted='#898781',
+    grid='#2c2c2a',
+    axis='#383835',
+    field='#3987e5',
+    beam='#d95926',
+    select='#199e70',
+    drift='#52514e',
+    marker='#ffffff',
+)
+
+
+def tokens(mode=None):
+    """Return the token set for `mode` (default from PUFFIN_VIZ_THEME)."""
+    mode = (mode or os.environ.get('PUFFIN_VIZ_THEME', 'light')).strip().lower()
+    return dict(_DARK) if mode == 'dark' else dict(_LIGHT)
+
+
+# ── Bokeh ────────────────────────────────────────────────────────────────────
+
+def bokeh_theme(t):
+    """A Bokeh Theme carrying the chrome: recessive axes, hairline grid, fonts.
+
+    Anything set here must NOT also be set on the figure in the caller — an
+    explicit value on the model beats the theme default.
+    """
+    from bokeh.themes import Theme
+    return Theme(json={'attrs': {
+        'Plot': {
+            'background_fill_color': t['surface'],
+            'border_fill_color': t['page'],
+            'outline_line_color': None,
+        },
+        'Axis': {
+            'axis_line_color': t['axis'],
+            'major_tick_line_color': t['axis'],
+            'minor_tick_line_color': None,
+            'axis_label_text_color': t['ink2'],
+            'axis_label_text_font': FONT,
+            'axis_label_text_font_size': '12px',
+            'axis_label_text_font_style': 'normal',
+            'major_label_text_color': t['muted'],
+            'major_label_text_font': FONT,
+            'major_label_text_font_size': '11px',
+        },
+        'Grid': {
+            'grid_line_color': t['grid'],
+            'grid_line_width': 1,
+            'grid_line_dash': 'solid',
+            'grid_line_alpha': 1.0,
+        },
+        'Title': {
+            'text_color': t['ink'],
+            'text_font': FONT,
+            'text_font_size': '13px',
+            'text_font_style': 'bold',
+        },
+        'Legend': {
+            'label_text_color': t['ink2'],
+            'label_text_font': FONT,
+            'label_text_font_size': '11px',
+            'background_fill_color': t['surface'],
+            'background_fill_alpha': 0.85,
+            'border_line_color': None,
+            'glyph_height': 12,
+            'glyph_width': 12,
+        },
+        'ColorBar': {
+            'background_fill_color': t['surface'],
+            'major_label_text_color': t['muted'],
+            'major_label_text_font': FONT,
+            'major_label_text_font_size': '10px',
+            'title_text_color': t['ink2'],
+            'title_text_font': FONT,
+            'title_text_font_size': '11px',
+            'title_text_font_style': 'normal',
+            'major_tick_line_color': t['axis'],
+            'bar_line_color': None,
+        },
+    }})
+
+
+def apply_page_style(doc, t):
+    """Style the plane behind the plots.
+
+    Bokeh prepends `{% extends base %}` to a string template itself, so this
+    must not carry its own — a second one raises "extended multiple times".
+    """
+    doc.template = ("""{% block preamble %}
+<style>
+  html, body {
+    background: """ + t['page'] + """;
+    margin: 0;
+    padding: 0 0 40px 0;
+    font-family: """ + FONT + """;
+  }
+</style>
+{% endblock %}
+""")
+
+
+def header_html(t, run, z, step, n_steps, extra='', unit='m'):
+    """Header block: run name, then z as the hero figure with a step counter.
+
+    The z readout uses tabular figures. The reference calls for proportional
+    figures on a hero number, but this one is rewritten in place on every
+    slider move — proportional digits make it visibly jitter as the width
+    of the string changes, so the columns rule applies here instead.
+    """
+    return f"""
+<div style="font-family:{FONT}; padding:2px 0 0 0;">
+  <div style="font-size:11px; letter-spacing:.09em; text-transform:uppercase;
+              color:{t['muted']};">{run}</div>
+  <div style="display:flex; align-items:baseline; gap:14px; margin-top:2px;">
+    <span style="font-size:30px; font-weight:600; color:{t['ink']};
+                 font-variant-numeric:tabular-nums; line-height:1.1;">
+      {z:.4f}<span style="font-size:15px; font-weight:400;
+                          color:{t['ink2']}; margin-left:3px;">{unit}</span></span>
+    <span style="font-size:12px; color:{t['ink2']};">
+      step <b style="font-variant-numeric:tabular-nums;">{step}</b>
+      <span style="color:{t['muted']};">of {n_steps}</span>{extra}</span>
+  </div>
+</div>"""
+
+
+def style_legend(fig, t):
+    """Legend chrome the theme cannot reach (it is created lazily by glyphs)."""
+    if not fig.legend:
+        return
+    lg = fig.legend[0]
+    lg.orientation = 'horizontal'
+    lg.spacing = 12
+    lg.padding = 4
+    lg.margin = 2
+    lg.label_text_font_size = '11px'
+
+
+# ── matplotlib (viewField3D.py) ──────────────────────────────────────────────
+
+def apply_matplotlib_style(t):
+    """Same chrome for the matplotlib viewer, so the family stays consistent."""
+    import matplotlib as mpl
+    mpl.rcParams.update({
+        'figure.facecolor':  t['page'],
+        'axes.facecolor':    t['surface'],
+        'axes.edgecolor':    t['axis'],
+        'axes.labelcolor':   t['ink2'],
+        'axes.titlecolor':   t['ink'],
+        'axes.titlesize':    11,
+        'axes.titleweight':  'bold',
+        'axes.labelsize':    10,
+        'axes.linewidth':    0.8,
+        'axes.grid':         True,
+        'grid.color':        t['grid'],
+        'grid.linewidth':    0.8,
+        'grid.linestyle':    '-',
+        'xtick.color':       t['muted'],
+        'ytick.color':       t['muted'],
+        'xtick.labelsize':   9,
+        'ytick.labelsize':   9,
+        'text.color':        t['ink'],
+        'font.size':         10,
+        'lines.linewidth':   2.0,
+        'lines.solid_capstyle':  'round',
+        'lines.solid_joinstyle': 'round',
+    })

--- a/utilities/pyPlotting/viewField1D_bokeh.py
+++ b/utilities/pyPlotting/viewField1D_bokeh.py
@@ -20,8 +20,15 @@ import h5py
 
 from bokeh.plotting import figure, curdoc
 from bokeh.models import (ColumnDataSource, Slider, LinearColorMapper,
-                           ColorBar, Div, Span, Range1d, RangeTool)
+                           ColorBar, Div, Span, Range1d, RangeTool,
+                           HoverTool, CrosshairTool, LinearAxis,
+                           RadioButtonGroup)
 from bokeh.layouts import column, row
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import puffin_viz_theme as pvt
+import puffin_viz_player as pvp
+import puffin_viz_data as pvd
 
 # ── physical constants ──────────────────────────────────────────────────────
 C0   = 2.99792458e8
@@ -72,14 +79,13 @@ def cycle_avg_intensity(xf, yf, attrs):
     return 2.0 * (ax2 + ay2)
 
 
-def temporal_profile(xf, yf, attrs):
-    """Cycle-averaged intensity (W/m²) and ct-z axis (µm)."""
-    iscale = intens_scale(attrs)
-    nz2    = int(attrs['nZ2'])
-    dz2    = float(attrs['sLengthOfElmZ2'])
-    Lc     = float(attrs['Lc'])
-    saxis  = np.arange(nz2) * dz2 * Lc * 1e6     # µm
-    intens = cycle_avg_intensity(xf, yf, attrs) * iscale
+def temporal_profile(xf, yf, attrs, u=None):
+    """Cycle-averaged intensity and the z2 axis, in u's units."""
+    u = u or UNITS
+    nz2 = int(attrs['nZ2'])
+    saxis = u.z2_axis(nz2, attrs)
+    intens = (cycle_avg_intensity(xf, yf, attrs)
+              * u.intensity_factor(intens_scale(attrs)))
     return saxis, intens
 
 
@@ -120,8 +126,7 @@ def load_electrons(path, attrs):
         data = f['electrons'][()]   # Fortran: (nMPs, 7); cols = x,y,z2,px,py,gam,chi
     if data.ndim == 2 and data.shape[1] == 7:
         data = data.T               # → (7, nMPs) so data[coord, :] indexes by coord
-    Lc      = float(attrs['Lc'])
-    z2_um   = data[2, :] * Lc * 1e6
+    z2_um   = data[2, :] * (UNITS.z2_mul)
     gam     = data[5, :]
     gam_mean = float(np.mean(gam))
     d_gam   = (gam - gam_mean) / gam_mean if gam_mean != 0 else gam - gam_mean
@@ -131,14 +136,28 @@ def load_electrons(path, attrs):
 def load_current(int_path, attrs):
     """Return (curr_x_µm, curr_A) arrays from an integrated HDF5 file.
 
-    The current mesh spans the same physical z2 range as the field mesh.
+    The current mesh is coarser than the field mesh (101 vs 2001 nodes here)
+    but covers the same span. Rather than assume that, take the bounds the
+    file declares on intCurrMeshSI — this panel shares its x-axis with the
+    field panels, so if the two meshes ever diverge, an assumed span would
+    silently misregister the beam against the radiation. Fall back to the
+    field span for older files that lack the mesh group.
     """
     with h5py.File(int_path, 'r') as f:
-        current = f['beamCurrentSI'][()]
-    nz2 = int(attrs['nZ2'])
-    dz2 = float(attrs['sLengthOfElmZ2'])
-    Lc  = float(attrs['Lc'])
-    x   = np.linspace(0.0, (nz2 - 1) * dz2 * Lc * 1e6, len(current))
+        current = f[UNITS.curr_key][()]
+        mesh = f.get('intCurrMeshSI')
+        lo = hi = None
+        if mesh is not None and not UNITS.scaled:
+            lo = mesh.attrs.get('vsLowerBounds')
+            hi = mesh.attrs.get('vsUpperBounds')
+
+    if lo is None or hi is None:
+        n = len(current)
+        # spread the (coarser) current mesh across the full z2 window
+        dz2 = float(attrs['sLengthOfElmZ2']) * (int(attrs['nZ2']) - 1) / max(n - 1, 1)
+        return np.arange(n) * dz2 * UNITS.z2_mul, current
+
+    x = np.linspace(float(lo) * 1e6, float(hi) * 1e6, len(current))
     return x, current
 
 
@@ -178,20 +197,34 @@ print('done', flush=True)
 int_files = sorted(
     glob.glob(os.path.join(data_dir, f'{basename}_integrated_*.h5')),
     key=step_num)
-pow_z, pow_W = np.array([]), np.array([])
+pow_z        = np.array([])
 int_z_vals   = np.array([])
+pow_attrs    = {}
+# Both unit systems up front so toggling never re-reads the integrated set.
+POW_W = {pvd.SCALED: np.array([]), pvd.SI: np.array([])}
+POW_J = {pvd.SCALED: np.array([]), pvd.SI: np.array([])}
 if int_files:
     print(f'Loading power curve ({len(int_files)} files)...', end=' ', flush=True)
-    pz, pw = [], []
+    pz = []
+    acc = {pvd.SCALED: ([], []), pvd.SI: ([], [])}
     for p in int_files:
         with h5py.File(p, 'r') as f:
-            ri = f['runInfo'].attrs
-            pz.append(float(ri['zTotal']))
-            pw.append(float(np.mean(f['powerSI'][()])))
-    pow_z      = np.array(pz)
-    pow_W      = np.where(np.array(pw) > 0, pw, np.nan)
+            pow_attrs = dict(f['runInfo'].attrs)
+            pz.append(float(pow_attrs['zTotal']))
+            for mode in (pvd.SCALED, pvd.SI):
+                u = pvd.Units(pow_attrs, mode)
+                arr = f[u.power_key][()]
+                # mean over z2 on a periodic mesh, peak on a temporal one —
+                # see puffin_viz_data.reduce_power
+                acc[mode][0].append(pvd.reduce_power(arr, pow_attrs)[0])
+                acc[mode][1].append(u.energy(arr, pow_attrs))
+    pow_z = np.array(pz)
+    for mode in (pvd.SCALED, pvd.SI):
+        w, j = acc[mode]
+        POW_W[mode] = np.where(np.array(w) > 0, w, np.nan)
+        POW_J[mode] = np.where(np.array(j) > 0, j, np.nan)
     int_z_vals = pow_z.copy()
-    print('done', flush=True)
+    print(f'done  ({pvd.reduce_power(np.array([1.0]), pow_attrs)[1]})', flush=True)
 
 
 def _closest_int_file(z):
@@ -235,13 +268,29 @@ def parse_lattice(latt_path, lw):
                 elements.append(('QU', z, 0.0))
     return elements, z
 
-if latt_arg:
-    latt_file = latt_arg
-else:
+def find_lattice(latt_arg, data_dir):
+    """Resolve the lattice file, falling back to auto-detection.
+
+    An explicit path that does not exist is a typo, not a request for no
+    lattice — warn instead of silently drawing an empty lattice panel, which
+    looks like the run simply had no elements.
+    """
+    if latt_arg:
+        if os.path.exists(latt_arg):
+            return latt_arg
+        print(f'WARNING: lattice file not found: {latt_arg}'
+              '  — falling back to auto-detection', flush=True)
     candidates = (glob.glob(os.path.join(data_dir, '*.latt')) +
                   glob.glob(os.path.join(
                       os.path.dirname(os.path.abspath(data_dir)), '*.latt')))
-    latt_file = candidates[0] if candidates else None
+    if candidates:
+        return candidates[0]
+    print('WARNING: no .latt file found — lattice panel will be empty',
+          flush=True)
+    return None
+
+
+latt_file = find_lattice(latt_arg, data_dir)
 
 with h5py.File(aperp_files[0], 'r') as f:
     lambda_w = float(f['runInfo'].attrs.get('lambda_w', 0.0275))
@@ -255,6 +304,7 @@ if latt_file and os.path.exists(latt_file):
 
 # ── initial data ──────────────────────────────────────────────────────────────
 xf0, yf0, attrs0 = load_field_1d(aperp_files[0])
+UNITS = pvd.Units(attrs0, pvd.SI)     # default to SI; toggle switches it
 s0, intens0       = temporal_profile(xf0, yf0, attrs0)
 omega0, spec0     = spectral_profile(xf0, yf0, attrs0)
 
@@ -275,7 +325,8 @@ else:
 # One-cycle length in µm  (resonant wavelength = 4π·ρ·Lc)
 _rho = float(attrs0['rho'])
 _Lc  = float(attrs0['Lc'])
-cycle_len_um = 4.0 * np.pi * _rho * _Lc * 1e6
+cycle_len_um = 4.0 * np.pi * _rho * UNITS.z2_mul
+cycle_len_disp = [cycle_len_um]   # mutable: apply_units rescales it
 
 # Default phase-space x_range: one cycle centred on particle centroid
 _z_center = float(np.median(z2_ps0)) if len(z2_ps0) > 0 else float(np.mean(s0))
@@ -304,58 +355,162 @@ ps_yrange = Range1d(start=_py0, end=_py1)
 # ── figures ───────────────────────────────────────────────────────────────────
 TOOLS = 'pan,wheel_zoom,box_zoom,reset,save'
 PW    = 1000   # total plot width
-TW    = PW // 3 - 10   # width of each top panel
 HW    = PW // 2 - 10   # width of each half-width panel
+SLIDER_INSET = 90      # left margin keeping the slider off the window edge
+
+T = pvt.tokens()
+curdoc().theme = pvt.bokeh_theme(T)
+pvt.apply_page_style(curdoc(), T)
+
+
+def _hover(fig, renderer, xlab, xfmt, ylab, yfmt):
+    """Crosshair + vline tooltip — the default hover layer for a line panel."""
+    fig.add_tools(
+        HoverTool(renderers=[renderer], mode='vline', attachment='above',
+                  tooltips=[(xlab, f'@x{xfmt}'), (ylab, f'@y{yfmt}')]),
+        CrosshairTool(line_color=T['muted'], line_alpha=0.6, line_width=1))
 
 src_intens   = ColumnDataSource(dict(x=s0.tolist(),     y=intens0.tolist()))
 src_spec_lin = ColumnDataSource(dict(x=omega0.tolist(), y=spec0.tolist()))
 spec0_log = np.where(spec0 > 0, spec0, 1e-30)
 src_spec_log = ColumnDataSource(dict(x=omega0.tolist(), y=spec0_log.tolist()))
 
-p_intens = figure(title='Temporal intensity  (cycle-avg)',
-                  x_axis_label='ct − z  (µm)',
-                  y_axis_label='Intensity  (W m⁻²)',
-                  width=TW, height=320, tools=TOOLS)
-p_intens.line('x', 'y', source=src_intens, color='royalblue', line_width=1.5)
+# In 1D, power and intensity differ only by the fixed transverse area, so
+# the cycle-averaged curve is one series in two unit systems (measured: the
+# ratio is exactly pi here, constant to 0.000000% along the pulse, corr
+# 1.00000000). The right axis is therefore a unit relabel of the same line,
+# not a second series on its own scale — the usual objection to twin axes
+# does not apply, because no scaling choice can change their relative shape.
+def power_per_intensity(intens, power):
+    """Constant relating the plotted intensity curve to power, or None.
 
-_spec_ref = Span(location=1.0, dimension='height',
-                 line_color='red', line_dash='dashed', line_width=1)
-_spec_ref2 = Span(location=1.0, dimension='height',
-                  line_color='red', line_dash='dashed', line_width=1)
+    Derived from the data rather than from the scaling algebra so it cannot
+    drift out of step with whatever convention cycle_avg_intensity uses.
+    """
+    i = np.asarray(intens, float)
+    p = np.asarray(power, float)
+    if i.size == 0 or p.size != i.size:
+        return None
+    m = i > i.max() * 0.01
+    if not np.any(m) or p[m].max() <= 0:
+        return None
+    return float(np.median(p[m] / i[m]))
+
+
+def _cycle_avg_power(int_path, attrs):
+    """powerSI smoothed with the same window as cycle_avg_intensity."""
+    with h5py.File(int_path, 'r') as f:
+        pr = f[UNITS.power_key][()]
+    dz2 = float(attrs['sLengthOfElmZ2'])
+    rho = float(attrs['rho'])
+    nnl = max(3, int(np.round(4 * np.pi * rho / dz2)) + 1)
+    return _sliding_mean(pr, nnl)
+
+
+def _derive_i_per_p():
+    """Intensity->power factor for the current units, or None.
+
+    Scans for the first step with a non-zero field: a run seeded from noise
+    starts at exactly zero, where the ratio is undefined. The factor differs
+    between unit systems, so this is re-run whenever the units change.
+    """
+    for k in range(n_files):
+        ep = _closest_int_file(z_vals[k])
+        if not ep:
+            continue
+        xf, yf, a = load_field_1d(aperp_files[k])
+        _, i = temporal_profile(xf, yf, a)
+        c = _cycle_avg_power(ep, a)
+        if len(c) == len(i):
+            f = power_per_intensity(i, c)
+            if f:
+                return f
+    return None
+
+
+i_per_p = _derive_i_per_p()
+
+# Radiation panels all wear the "field" hue — see puffin_viz_theme.
+# An explicit Range1d for the left axis, not the default DataRange1d: the
+# right axis is a Range1d that honours the values pushed to it, while a
+# DataRange1d re-derives its own limits client-side. Mixing the two lets the
+# axes disagree, which would make the twin-axis reading wrong.
+p_intens = figure(title='Temporal profile  (cycle-avg)',
+                  x_axis_label=UNITS.z2_label,
+                  y_axis_label=UNITS.intens_label,
+                  y_range=Range1d(start=0.0, end=1.0),
+                  width=PW, height=300, tools=TOOLS)
+_r = p_intens.line('x', 'y', source=src_intens, color=T['field'], line_width=2)
+_hover(p_intens, _r, 'ct−z', '{0.0} µm', 'I', '{0.00e+0} W/m²')
+
+if i_per_p:
+    # Right axis: the same curve read as power. Both ranges are set
+    # explicitly and together (see _sync_intens_axes) so they can never
+    # drift apart under autoscaling.
+    p_intens.extra_y_ranges = {'power': Range1d(start=0.0, end=1.0)}
+    p_intens.add_layout(
+        LinearAxis(y_range_name='power',
+                   axis_label=UNITS.power_label), 'right')
+
+    def _sync_intens_axes(intens):
+        hi = float(np.max(intens)) if len(intens) else 0.0
+        hi = hi * 1.05 if hi > 0 else 1.0
+        p_intens.y_range.start = 0.0
+        p_intens.y_range.end = hi
+        p_intens.extra_y_ranges['power'].start = 0.0
+        p_intens.extra_y_ranges['power'].end = hi * i_per_p
+
+    _sync_intens_axes(intens0)
+else:
+    def _sync_intens_axes(intens):
+        pass
+
+# ω/ωr = 1 is the resonance: a reference line, so it stays in muted ink
+# rather than taking a series hue.
+_spec_ref = Span(location=1.0, dimension='height', line_color=T['muted'],
+                 line_dash='dashed', line_width=1)
+_spec_ref2 = Span(location=1.0, dimension='height', line_color=T['muted'],
+                  line_dash='dashed', line_width=1)
 
 p_spec = figure(title='Spectral intensity  (linear)',
                 x_axis_label='ω / ωᵣ',
                 y_axis_label='Intensity  (a.u.)',
-                width=TW, height=320, tools=TOOLS)
-p_spec.line('x', 'y', source=src_spec_lin, color='darkorange', line_width=1.5)
+                width=HW, height=300, tools=TOOLS)
+_r = p_spec.line('x', 'y', source=src_spec_lin, color=T['field'], line_width=2)
+_hover(p_spec, _r, 'ω/ωᵣ', '{0.000}', 'I', '{0.000}')
 p_spec.add_layout(_spec_ref)
 
 p_spec_log = figure(title='Spectral intensity  (log)',
                     x_axis_label='ω / ωᵣ',
                     y_axis_label='Intensity  (a.u.)',
                     x_range=p_spec.x_range,
-                    width=TW, height=320, tools=TOOLS,
+                    width=HW, height=300, tools=TOOLS,
                     y_axis_type='log')
-p_spec_log.line('x', 'y', source=src_spec_log, color='darkorange', line_width=1.5)
+_r = p_spec_log.line('x', 'y', source=src_spec_log, color=T['field'], line_width=2)
+_hover(p_spec_log, _r, 'ω/ωᵣ', '{0.000}', 'I', '{0.00e+0}')
 p_spec_log.add_layout(_spec_ref2)
 
 
 # ── current profile panel ─────────────────────────────────────────────────────
 src_curr = ColumnDataSource(dict(x=curr_x0.tolist(), y=curr_A0.tolist()))
 
-p_current = figure(title='Beam current  (drag green window → moves phase-space view)',
-                   x_axis_label='ct − z  (µm)',
-                   y_axis_label='Current  (A)',
+# Electron-beam panels wear the "beam" hue.
+p_current = figure(title='Beam current  (drag the window → moves phase-space view)',
+                   x_axis_label=UNITS.z2_label,
+                   y_axis_label=UNITS.curr_label,
                    x_range=p_intens.x_range,   # shares field x-axis
                    width=HW, height=280, tools='wheel_zoom,box_zoom,reset,save')
-p_current.line('x', 'y', source=src_curr, color='steelblue', line_width=1.5)
+_r = p_current.line('x', 'y', source=src_curr, color=T['beam'], line_width=2)
+_hover(p_current, _r, 'ct−z', '{0.0} µm', 'I', '{0.0} A')
 
-# RangeTool: draggable/resizable box that directly drives ps_xrange
+# RangeTool: draggable/resizable box that directly drives ps_xrange. It is a
+# control rather than data, so it takes the "select" hue — distinct from the
+# beam trace underneath it and from the field hue elsewhere.
 range_tool = RangeTool(x_range=ps_xrange)
-range_tool.overlay.fill_color  = 'green'
+range_tool.overlay.fill_color  = T['select']
 range_tool.overlay.fill_alpha  = 0.12
-range_tool.overlay.line_color  = 'green'
-range_tool.overlay.line_width  = 1.2
+range_tool.overlay.line_color  = T['select']
+range_tool.overlay.line_width  = 1.5
 p_current.add_tools(range_tool)
 
 
@@ -363,13 +518,15 @@ p_current.add_tools(range_tool)
 src_phase = ColumnDataSource(dict(x=z2_ps0.tolist(), y=dgam0.tolist()))
 
 p_phase = figure(title='Electron phase space  (one-cycle zoom)',
-                 x_axis_label='ct − z  (µm)',
+                 x_axis_label=UNITS.z2_label,
                  y_axis_label='Δγ / ⟨γ⟩',
                  x_range=ps_xrange,
                  y_range=ps_yrange,
                  width=HW, height=280, tools=TOOLS)
+# No hover here: this is 10^5-plus macroparticles, and a per-mark hit test at
+# that count stalls the pan/zoom the panel is actually for.
 p_phase.scatter('x', 'y', source=src_phase,
-                color='tomato', size=1.5, alpha=0.5)
+                color=T['beam'], size=1.5, alpha=0.45)
 
 
 def _rescale_ps_y():
@@ -389,24 +546,84 @@ ps_xrange.on_change('end',   _ps_range_cb)
 
 
 # ── power vs z plot ───────────────────────────────────────────────────────────
-ylo = float(np.nanmin(pow_W)) if len(pow_W) else 1e-3
-yhi = float(np.nanmax(pow_W)) if len(pow_W) else 1e10
+# Series for the active unit system; apply_units() swaps these on toggle.
+pow_W = POW_W[UNITS.mode]
+pow_J = POW_J[UNITS.mode]
 
-p_power = figure(title='Power vs z',
-                 x_axis_label='z (m)', y_axis_label='Power (W)',
-                 width=PW, height=220, tools=TOOLS, y_axis_type='log')
+# Every dump can be zero power (a run seeded from noise that has not gained
+# yet), and those are masked to NaN above — so check for a finite value, not
+# just a non-empty array, or nanmin warns and returns NaN.
+if len(pow_W) and np.any(np.isfinite(pow_W)):
+    ylo = float(np.nanmin(pow_W)); yhi = float(np.nanmax(pow_W))
+else:
+    ylo, yhi = 1e-3, 1e10
+
+# Log only when the curve actually spans decades. Start-to-saturation gain
+# does and needs it; a short or already-saturated run spans well under a
+# decade, and a log axis then crowds every tick into the top of the frame
+# where the labels overlap and cannot be read.
+_pow_decades = (yhi / ylo) if ylo > 0 else float('inf')
+_pow_axis = 'log' if _pow_decades >= 100 else 'linear'
+
+# Span the simulated z, not the lattice. p_latt shares this range, so a run
+# that covers only the head of a long lattice (a truncated test case) would
+# otherwise squash its whole power curve into a sliver at x=0 to make room
+# for undulators that were never simulated.
+_zs = np.concatenate([a for a in (z_vals, pow_z) if len(a)])
+_zpad = max((float(_zs.max()) - float(_zs.min())) * 0.02, 1e-6)
+_zrange = Range1d(start=float(_zs.min()) - _zpad, end=float(_zs.max()) + _zpad)
+
+p_power = figure(title=UNITS.power_title(pow_attrs),
+                 x_axis_label=UNITS.z_label,
+                 y_axis_label=UNITS.power_label,
+                 x_range=_zrange,
+                 width=HW, height=230, tools=TOOLS, y_axis_type=_pow_axis)
 if len(pow_z):
-    src_pow = ColumnDataSource(dict(x=pow_z.tolist(), y=pow_W.tolist()))
-    p_power.line('x', 'y', source=src_pow, color='royalblue', line_width=1.5)
+    src_pow = ColumnDataSource(dict(x=(pow_z*UNITS.z_mul).tolist(),
+                                    y=pow_W.tolist()))
+    _r = p_power.line('x', 'y', source=src_pow, color=T['field'], line_width=2)
+    _hover(p_power, _r, 'z', '{0.000} m',
+           pvd.reduce_power(np.array([1.0]), pow_attrs)[1], '{0.00e+0} W')
 
-src_vline = ColumnDataSource(dict(x0=[z_vals[0]], y0=[ylo],
-                                  x1=[z_vals[0]], y1=[yhi]))
+# The current-z cue is chrome, not a series: primary ink, dashed.
+src_vline = ColumnDataSource(dict(x0=[z_vals[0]*UNITS.z_mul], y0=[ylo],
+                                  x1=[z_vals[0]*UNITS.z_mul], y1=[yhi]))
 p_power.segment('x0', 'y0', 'x1', 'y1', source=src_vline,
-                color='red', line_dash='dashed', line_width=1.5)
+                color=T['marker'], line_dash='dashed', line_width=2)
+
+
+# ── energy vs z ───────────────────────────────────────────────────────────────
+# Peak power and energy answer different questions (how intense the spike is
+# vs how much light there is in total), so they get their own panels rather
+# than a second y-axis on one plot.
+if len(pow_J) and np.any(np.isfinite(pow_J)):
+    _elo, _ehi = float(np.nanmin(pow_J)), float(np.nanmax(pow_J))
+else:
+    _elo, _ehi = 1e-12, 1e-3
+_e_axis = 'log' if (_elo > 0 and _ehi / _elo >= 100) else 'linear'
+
+p_energy = figure(title=UNITS.energy_title(pow_attrs),
+                  x_axis_label=UNITS.z_label,
+                  y_axis_label=UNITS.energy_label,
+                  x_range=_zrange,
+                  width=HW, height=230, tools=TOOLS, y_axis_type=_e_axis)
+if len(pow_z):
+    src_en = ColumnDataSource(dict(x=(pow_z*UNITS.z_mul).tolist(),
+                                   y=pow_J.tolist()))
+    _r = p_energy.line('x', 'y', source=src_en, color=T['field'], line_width=2)
+    _hover(p_energy, _r, 'z', '{0.000} m', 'E', '{0.000e+0} J')
+
+src_evline = ColumnDataSource(dict(x0=[z_vals[0]*UNITS.z_mul], y0=[_elo],
+                                   x1=[z_vals[0]*UNITS.z_mul], y1=[_ehi]))
+p_energy.segment('x0', 'y0', 'x1', 'y1', source=src_evline,
+                 color=T['marker'], line_dash='dashed', line_width=2)
+
+
+
 
 # lattice diagram
 p_latt = figure(title='Lattice',
-                x_axis_label='z (m)',
+                x_axis_label=UNITS.z_label,
                 x_range=p_power.x_range,
                 width=PW, height=90, tools='pan,reset',
                 y_range=(-0.05, 1.05))
@@ -415,67 +632,150 @@ p_latt.ygrid.visible = False
 p_latt.xgrid.visible = False
 
 if latt_elements:
-    un_x, un_y, un_w, un_h     = [], [], [], []
-    dr_x, dr_y, dr_w, dr_h     = [], [], [], []
-    ch_x, ch_y, ch_w, ch_h     = [], [], [], []
-    ch_x0, ch_y0, ch_x1, ch_y1 = [], [], [], []   # zero-length chicanes as lines
-    qu_x0, qu_y0, qu_x1, qu_y1 = [], [], [], []
+    # CDS-backed so element positions can be rescaled when the unit system
+    # changes; plain lists would be baked in at construction.
+    src_dr = ColumnDataSource(dict(x=[], y=[], w=[], h=[]))
+    src_un = ColumnDataSource(dict(x=[], y=[], w=[], h=[]))
+    src_ch = ColumnDataSource(dict(x=[], y=[], w=[], h=[]))
+    src_ch0 = ColumnDataSource(dict(x0=[], y0=[], x1=[], y1=[]))
+    src_qu = ColumnDataSource(dict(x0=[], y0=[], x1=[], y1=[]))
 
-    for typ, zs, L in latt_elements:
-        if typ == 'UN':
-            un_x.append(zs + L/2); un_y.append(0.5)
-            un_w.append(L);        un_h.append(0.9)
-        elif typ == 'DR' and L > 0:
-            dr_x.append(zs + L/2); dr_y.append(0.5)
-            dr_w.append(L);        dr_h.append(0.5)
-        elif typ == 'CH':
-            if L > 0:
-                ch_x.append(zs + L/2); ch_y.append(0.5)
-                ch_w.append(L);        ch_h.append(0.7)
-            else:
-                ch_x0.append(zs); ch_y0.append(0.05)
-                ch_x1.append(zs); ch_y1.append(0.95)
-        elif typ == 'QU':
-            qu_x0.append(zs); qu_y0.append(0.05)
-            qu_x1.append(zs); qu_y1.append(0.95)
+    def _relayout_lattice():
+        """Rebuild the lattice glyph positions for the current units."""
+        zmul = UNITS.z_mul
+        span = (latt_z_total * zmul) if latt_z_total > 0 else 1.0
+        # A 2px gap in the surface colour separates touching elements;
+        # convert 2px of the plot's own width into the displayed z units.
+        gap = 2.0 / PW * span
+        d = {k: dict(x=[], y=[], w=[], h=[]) for k in ('DR', 'UN', 'CH')}
+        c0 = dict(x0=[], y0=[], x1=[], y1=[])
+        q = dict(x0=[], y0=[], x1=[], y1=[])
+        for typ, zs, L in latt_elements:
+            zs, L = zs * zmul, L * zmul
+            Lw = max(L - gap, L * 0.5)
+            if typ == 'QU':
+                q['x0'].append(zs); q['y0'].append(0.05)
+                q['x1'].append(zs); q['y1'].append(0.95)
+            elif typ == 'CH' and L <= 0:
+                c0['x0'].append(zs); c0['y0'].append(0.05)
+                c0['x1'].append(zs); c0['y1'].append(0.95)
+            elif typ in d and (L > 0 or typ == 'UN'):
+                h = {'UN': 0.9, 'DR': 0.5, 'CH': 0.7}[typ]
+                d[typ]['x'].append(zs + L/2); d[typ]['y'].append(0.5)
+                d[typ]['w'].append(Lw);       d[typ]['h'].append(h)
+        src_dr.data, src_un.data, src_ch.data = d['DR'], d['UN'], d['CH']
+        src_ch0.data, src_qu.data = c0, q
 
-    if dr_x:
-        p_latt.rect(dr_x, dr_y, dr_w, dr_h, color='#CCCCCC',
-                    line_color=None, alpha=0.6, legend_label='Drift')
-    if un_x:
-        p_latt.rect(un_x, un_y, un_w, un_h, color='#2176AE',
-                    line_color='white', line_width=0.5, legend_label='Undulator')
-    if ch_x:
-        p_latt.rect(ch_x, ch_y, ch_w, ch_h, color='#E87D2B',
+    _relayout_lattice()
+
+    # Drift is the absence of an element, so it stays chrome grey; the three
+    # real element types take the validated hues.
+    if src_dr.data['x']:
+        p_latt.rect('x', 'y', 'w', 'h', source=src_dr, color=T['drift'],
+                    line_color=None, alpha=0.45, legend_label='Drift')
+    if src_un.data['x']:
+        p_latt.rect('x', 'y', 'w', 'h', source=src_un, color=T['field'],
+                    line_color=None, legend_label='Undulator')
+    if src_ch.data['x']:
+        p_latt.rect('x', 'y', 'w', 'h', source=src_ch, color=T['beam'],
                     line_color=None, legend_label='Chicane')
-    if ch_x0:
-        p_latt.segment(ch_x0, ch_y0, ch_x1, ch_y1, color='#E87D2B',
-                       line_width=2.5, legend_label='Chicane')
-    if qu_x0:
-        p_latt.segment(qu_x0, qu_y0, qu_x1, qu_y1, color='#D62839',
-                       line_width=2, legend_label='Quad')
+    if src_ch0.data['x0']:
+        p_latt.segment('x0', 'y0', 'x1', 'y1', source=src_ch0,
+                       color=T['beam'], line_width=2.5, legend_label='Chicane')
+    if src_qu.data['x0']:
+        p_latt.segment('x0', 'y0', 'x1', 'y1', source=src_qu,
+                       color=T['select'], line_width=2, legend_label='Quad')
 
-    p_latt.legend.orientation = 'horizontal'
-    p_latt.legend.label_text_font_size = '9pt'
-    p_latt.legend.spacing = 10
-    p_latt.legend.padding = 4
+    pvt.style_legend(p_latt, T)
     p_latt.add_layout(p_latt.legend[0], 'below')
 
-src_lmark = ColumnDataSource(dict(x0=[z_vals[0]], y0=[0.0],
-                                  x1=[z_vals[0]], y1=[1.0]))
+src_lmark = ColumnDataSource(dict(x0=[z_vals[0]*UNITS.z_mul], y0=[0.0],
+                                  x1=[z_vals[0]*UNITS.z_mul], y1=[1.0]))
 p_latt.segment('x0', 'y0', 'x1', 'y1', source=src_lmark,
-               color='red', line_dash='dashed', line_width=1.5)
+               color=T['marker'], line_dash='dashed', line_width=2)
 
 
 # ── status + slider ───────────────────────────────────────────────────────────
 def _status_html(idx):
-    return (f'<span style="font-size:13px"><b>Step {idx+1}/{n_files}</b>'
-            f' &nbsp;|&nbsp; file step {step_num(aperp_files[idx])}'
-            f' &nbsp;|&nbsp; z = {z_vals[idx]:.4f} m</span>')
+    return pvt.header_html(
+        T, f'{basename} · 1D field', z_vals[idx] * UNITS.z_mul, idx + 1, n_files,
+        unit=('' if UNITS.scaled else 'm'),
+        extra=f' <span style="color:{T["muted"]};">· file step '
+              f'{step_num(aperp_files[idx])}</span>')
 
-status = Div(text=_status_html(0), width=PW)
-slider = Slider(start=0, end=n_files - 1, value=0, step=1,
-                title=f'z = {z_vals[0]:.3f} m', width=PW)
+status = Div(text=_status_html(0), width=PW,
+             margin=(14, 10, 4, SLIDER_INSET))
+# Inset from the left so the handle at step 0 is clear of the window edge —
+# dragging there otherwise grabs the browser's resize border.
+# Bokeh rejects start == end, which is what a single-dump run would give.
+slider = Slider(start=0, end=max(n_files - 1, 1), value=0, step=1,
+                disabled=n_files < 2,
+                # No title: the header above already shows z as its hero
+                # figure and the frame counter beside it. Bokeh renders
+                # "<title>: <value>", so a title here gives either a
+                # duplicated z or, with show_value off, a dangling colon.
+                title=None, show_value=False,
+                width=PW - SLIDER_INSET - 40,
+                margin=(5, 40, 15, SLIDER_INSET))
+
+
+def apply_units():
+    """Re-label and re-scale every panel for the current UNITS."""
+    global pow_W, pow_J, ylo, yhi, _elo, _ehi, i_per_p
+
+    pow_W = POW_W[UNITS.mode]
+    pow_J = POW_J[UNITS.mode]
+    zs = pow_z * UNITS.z_mul
+    if len(pow_z):
+        src_pow.data = dict(x=zs.tolist(), y=pow_W.tolist())
+        src_en.data  = dict(x=zs.tolist(), y=pow_J.tolist())
+    _z = np.concatenate([a for a in (z_vals * UNITS.z_mul, zs) if len(a)])
+    pad = max((float(_z.max()) - float(_z.min())) * 0.02, 1e-9)
+    _zrange.start, _zrange.end = float(_z.min()) - pad, float(_z.max()) + pad
+
+    if len(pow_W) and np.any(np.isfinite(pow_W)):
+        ylo, yhi = float(np.nanmin(pow_W)), float(np.nanmax(pow_W))
+    if len(pow_J) and np.any(np.isfinite(pow_J)):
+        _elo, _ehi = float(np.nanmin(pow_J)), float(np.nanmax(pow_J))
+
+    p_power.title.text = UNITS.power_title(pow_attrs)
+    p_power.xaxis.axis_label = UNITS.z_label
+    p_power.yaxis.axis_label = UNITS.power_label
+    p_energy.title.text = UNITS.energy_title(pow_attrs)
+    p_energy.xaxis.axis_label = UNITS.z_label
+    p_energy.yaxis.axis_label = UNITS.energy_label
+    p_intens.xaxis.axis_label = UNITS.z2_label
+    p_intens.yaxis.axis_label = UNITS.intens_label
+    p_current.xaxis.axis_label = UNITS.z2_label
+    p_current.yaxis.axis_label = UNITS.curr_label
+    p_phase.xaxis.axis_label = UNITS.z2_label
+    if latt_elements:
+        p_latt.xaxis.axis_label = UNITS.z_label
+        _relayout_lattice()
+
+    # The intensity->power factor is unit-dependent, so re-derive it.
+    i_per_p = _derive_i_per_p()
+    if i_per_p and p_intens.right:
+        p_intens.right[0].axis_label = UNITS.power_label
+
+    # phase-space x window is in z2 units
+    c = 4.0 * np.pi * float(attrs0['rho']) * UNITS.z2_mul
+    mid = 0.5 * (ps_xrange.start + ps_xrange.end)
+    ratio = c / max(cycle_len_disp[0], 1e-30)
+    cycle_len_disp[0] = c
+    ps_xrange.start, ps_xrange.end = mid*ratio - c/2, mid*ratio + c/2
+
+    update(None, None, None)
+
+
+def _on_units(attr, old, new):
+    global UNITS
+    UNITS = pvd.Units(attrs0, pvd.SCALED if int(new) == 0 else pvd.SI)
+    apply_units()
+
+
+units_btn = RadioButtonGroup(labels=['Scaled', 'SI'], active=pvd.SI, width=170)
+units_btn.on_change('active', _on_units)
 
 
 def update(attr, old, new):
@@ -487,6 +787,7 @@ def update(attr, old, new):
 
     spec_log = np.where(spec > 0, spec, 1e-30)
     src_intens.data   = dict(x=s.tolist(),         y=intens.tolist())
+    _sync_intens_axes(intens)
     src_spec_lin.data = dict(x=omega.tolist(),      y=spec.tolist())
     src_spec_log.data = dict(x=omega.tolist(),      y=spec_log.tolist())
 
@@ -507,23 +808,39 @@ def update(attr, old, new):
     else:
         src_curr.data = dict(x=[], y=[])
 
-    z = z_vals[idx]
-    src_vline.data = dict(x0=[z], y0=[ylo], x1=[z], y1=[yhi])
-    src_lmark.data = dict(x0=[z], y0=[0.0], x1=[z], y1=[1.0])
+    z  = z_vals[idx]
+    zd = z * UNITS.z_mul          # z in the displayed units
+    src_vline.data  = dict(x0=[zd], y0=[ylo],  x1=[zd], y1=[yhi])
+    src_evline.data = dict(x0=[zd], y0=[_elo], x1=[zd], y1=[_ehi])
+    src_lmark.data  = dict(x0=[zd], y0=[0.0],  x1=[zd], y1=[1.0])
 
-    slider.title = f'z = {z:.3f} m'
+
+
     status.text  = _status_html(idx)
 
 
 slider.on_change('value', update)
 
+# Playback. Registered after `update` so a timer tick redraws the panels
+# before the player's own slider handler runs.
+player = pvp.Player(curdoc(), slider, n_files, T)
+
 # ── layout ────────────────────────────────────────────────────────────────────
-curdoc().add_root(column(
-    status,
-    row(p_intens, p_spec, p_spec_log),
-    row(p_current, p_phase),
-    p_power,
-    p_latt,
-    slider,
-))
+# A deck with no lattice file would otherwise get an empty titled panel with
+# just an axis in it — the power plot already carries the z cue, so drop it
+# rather than show a blank.
+_panels = [status,
+           row(player.layout(inset=SLIDER_INSET, top=0, bottom=0),
+               units_btn),
+           slider]
+if latt_elements:
+    _panels.append(p_latt)
+# The temporal panel carries two y-axes, so it gets a full-width row of its
+# own rather than a third of one — at TW the axes left almost no plot area.
+_panels += [row(p_power, p_energy),
+            p_intens,
+            row(p_spec, p_spec_log),
+            row(p_current, p_phase)]
+
+curdoc().add_root(column(*_panels))
 curdoc().title = f'Puffin 1D Field Viewer — {basename}'

--- a/utilities/pyPlotting/viewField1D_bokeh.py
+++ b/utilities/pyPlotting/viewField1D_bokeh.py
@@ -1,0 +1,529 @@
+#!/usr/bin/env python3
+"""
+Interactive Bokeh viewer for Puffin 1D field output (aperp_*.h5).
+
+Run with:
+    bokeh serve --show viewField1D_bokeh.py --args /path/to/data [basename] [lattice.latt]
+
+Layout:
+    Top row  — temporal intensity profile (W/m²) vs ct-z (µm)
+               spectral intensity (a.u.) vs ω/ωr  (linear + log)
+    Mid row  — beam current (A) vs ct-z (µm)  [with phase-space zoom indicator]
+               electron phase space Δγ/⟨γ⟩ vs ct-z (µm)  [zoomed to one cycle]
+    Lower    — power vs z (from integrated files)
+    Bottom   — lattice diagram + slider
+"""
+
+import sys, os, glob, re
+import numpy as np
+import h5py
+
+from bokeh.plotting import figure, curdoc
+from bokeh.models import (ColumnDataSource, Slider, LinearColorMapper,
+                           ColorBar, Div, Span, Range1d, RangeTool)
+from bokeh.layouts import column, row
+
+# ── physical constants ──────────────────────────────────────────────────────
+C0   = 2.99792458e8
+QE   = 1.60217653e-19
+EPS0 = 8.854187817e-12
+ME   = 9.1093826e-31
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def step_num(path):
+    m = re.search(r'_(\d+)\.h5$', path)
+    return int(m.group(1)) if m else 0
+
+
+def intens_scale(attrs):
+    return C0 * EPS0 * (attrs['gamma_r'] * ME * C0**2
+                        / (QE * attrs['kappa'] * attrs['Lg']))**2
+
+
+def load_field_1d(path):
+    """Return xf, yf (shape nz2), and attrs dict.
+    h5py reads the Fortran-written array as (2, nz2): axis 0 = component."""
+    with h5py.File(path, 'r') as f:
+        aperp = f['aperp'][()]   # (2, nz2)
+        attrs = dict(f['runInfo'].attrs)
+    xf = aperp[0, :]
+    yf = aperp[1, :]
+    return xf, yf, attrs
+
+
+def _sliding_mean(arr, n):
+    """O(n) sliding window mean of length n, edge-padded."""
+    padded = np.pad(arr, (n // 2, n - 1 - n // 2), mode='edge')
+    cs     = np.insert(np.cumsum(padded), 0, 0)
+    return (cs[n:] - cs[:-n]) / n
+
+
+def cycle_avg_intensity(xf, yf, attrs):
+    """Peak amplitude squared, cycle-averaged over one resonant period."""
+    nz2   = int(attrs['nZ2'])
+    dz2   = float(attrs['sLengthOfElmZ2'])
+    rho   = float(attrs['rho'])
+    lr    = 4 * np.pi * rho
+    nnl   = max(3, int(np.round(lr / dz2)) + 1)
+    ax2   = _sliding_mean(xf**2, nnl)
+    ay2   = _sliding_mean(yf**2, nnl)
+    return 2.0 * (ax2 + ay2)
+
+
+def temporal_profile(xf, yf, attrs):
+    """Cycle-averaged intensity (W/m²) and ct-z axis (µm)."""
+    iscale = intens_scale(attrs)
+    nz2    = int(attrs['nZ2'])
+    dz2    = float(attrs['sLengthOfElmZ2'])
+    Lc     = float(attrs['Lc'])
+    saxis  = np.arange(nz2) * dz2 * Lc * 1e6     # µm
+    intens = cycle_avg_intensity(xf, yf, attrs) * iscale
+    return saxis, intens
+
+
+def spectral_profile(xf, yf, attrs):
+    """Normalised spectral intensity and ω/ωr axis."""
+    nz2  = int(attrs['nZ2'])
+    dz2  = float(attrs['sLengthOfElmZ2'])
+    rho  = float(attrs['rho'])
+    lenz2 = (nz2 - 1) * dz2
+    fs    = nz2 / lenz2
+    npts  = int(np.ceil((nz2 + 1) / 2))
+
+    ftx = np.fft.fft(xf)
+    fty = np.fft.fft(yf)
+
+    px = np.abs(ftx[:npts])**2
+    py = np.abs(fty[:npts])**2
+    for p in (px, py):
+        if nz2 % 2 == 1:
+            p[1:] *= 2
+        else:
+            p[1:-1] *= 2
+
+    spec = px + py
+    spec_norm = spec / np.max(spec) if np.max(spec) > 0 else spec
+
+    omega_axis = np.arange(npts) * (fs / nz2) * (4 * np.pi * rho)
+    return omega_axis, spec_norm
+
+
+def load_electrons(path, attrs):
+    """Return (z2_µm, d_gam_rel) from an electron HDF5 file.
+
+    z2_µm   — macroparticle ct-z positions in µm
+    d_gam_rel — fractional energy deviation (γ - ⟨γ⟩) / ⟨γ⟩
+    """
+    with h5py.File(path, 'r') as f:
+        data = f['electrons'][()]   # Fortran: (nMPs, 7); cols = x,y,z2,px,py,gam,chi
+    if data.ndim == 2 and data.shape[1] == 7:
+        data = data.T               # → (7, nMPs) so data[coord, :] indexes by coord
+    Lc      = float(attrs['Lc'])
+    z2_um   = data[2, :] * Lc * 1e6
+    gam     = data[5, :]
+    gam_mean = float(np.mean(gam))
+    d_gam   = (gam - gam_mean) / gam_mean if gam_mean != 0 else gam - gam_mean
+    return z2_um, d_gam
+
+
+def load_current(int_path, attrs):
+    """Return (curr_x_µm, curr_A) arrays from an integrated HDF5 file.
+
+    The current mesh spans the same physical z2 range as the field mesh.
+    """
+    with h5py.File(int_path, 'r') as f:
+        current = f['beamCurrentSI'][()]
+    nz2 = int(attrs['nZ2'])
+    dz2 = float(attrs['sLengthOfElmZ2'])
+    Lc  = float(attrs['Lc'])
+    x   = np.linspace(0.0, (nz2 - 1) * dz2 * Lc * 1e6, len(current))
+    return x, current
+
+
+# ── collect aperp files ───────────────────────────────────────────────────────
+
+args     = sys.argv[1:]
+data_dir = args[0] if args else '.'
+basename = args[1] if len(args) > 1 else None
+latt_arg = args[2] if len(args) > 2 else None
+
+all_h5 = glob.glob(os.path.join(data_dir, '*_aperp_*.h5'))
+if not all_h5:
+    raise RuntimeError(f'No aperp HDF5 files found in {data_dir}')
+
+if basename is None:
+    basename = re.sub(r'_aperp_\d+\.h5$', '',
+                      os.path.basename(sorted(all_h5, key=step_num)[0]))
+
+aperp_files = sorted(
+    glob.glob(os.path.join(data_dir, f'{basename}_aperp_*.h5')),
+    key=step_num)
+n_files = len(aperp_files)
+print(f'Found {n_files} aperp files  (basename="{basename}")', flush=True)
+
+
+# ── pre-scan z positions ──────────────────────────────────────────────────────
+print('Scanning z positions...', end=' ', flush=True)
+z_vals = []
+for p in aperp_files:
+    with h5py.File(p, 'r') as f:
+        z_vals.append(float(f['runInfo'].attrs['zTotal']))
+z_vals = np.array(z_vals)
+print('done', flush=True)
+
+
+# ── power curve from integrated files ─────────────────────────────────────────
+int_files = sorted(
+    glob.glob(os.path.join(data_dir, f'{basename}_integrated_*.h5')),
+    key=step_num)
+pow_z, pow_W = np.array([]), np.array([])
+int_z_vals   = np.array([])
+if int_files:
+    print(f'Loading power curve ({len(int_files)} files)...', end=' ', flush=True)
+    pz, pw = [], []
+    for p in int_files:
+        with h5py.File(p, 'r') as f:
+            ri = f['runInfo'].attrs
+            pz.append(float(ri['zTotal']))
+            pw.append(float(np.mean(f['powerSI'][()])))
+    pow_z      = np.array(pz)
+    pow_W      = np.where(np.array(pw) > 0, pw, np.nan)
+    int_z_vals = pow_z.copy()
+    print('done', flush=True)
+
+
+def _closest_int_file(z):
+    """Return the integrated file path whose z is closest to z, or None."""
+    if len(int_z_vals) == 0:
+        return None
+    return int_files[int(np.argmin(np.abs(int_z_vals - z)))]
+
+
+# ── collect electron files by step number ─────────────────────────────────────
+elec_files_by_step = {
+    step_num(p): p
+    for p in glob.glob(os.path.join(data_dir, f'{basename}_electrons_*.h5'))
+}
+print(f'Found {len(elec_files_by_step)} electron file(s)', flush=True)
+
+
+def _elec_file_for(aperp_idx):
+    """Return electron file path matching aperp file index, or None."""
+    return elec_files_by_step.get(step_num(aperp_files[aperp_idx]))
+
+
+# ── lattice ───────────────────────────────────────────────────────────────────
+def parse_lattice(latt_path, lw):
+    elements, z = [], 0.0
+    with open(latt_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith('!'): continue
+            tag  = line[:2].upper()
+            nums = list(map(float, re.findall(
+                r'[-+]?\d*\.?\d+(?:[eE][-+]?\d+)?', line[2:])))
+            if tag == 'UN' and nums:
+                L = int(nums[0]) * lw; elements.append(('UN', z, L)); z += L
+            elif tag == 'DR' and nums:
+                L = nums[0] * lw;      elements.append(('DR', z, L)); z += L
+            elif tag == 'CH' and nums:
+                L = nums[0] * lw
+                elements.append(('CH', z, L)); z += L
+            elif tag == 'QU':
+                elements.append(('QU', z, 0.0))
+    return elements, z
+
+if latt_arg:
+    latt_file = latt_arg
+else:
+    candidates = (glob.glob(os.path.join(data_dir, '*.latt')) +
+                  glob.glob(os.path.join(
+                      os.path.dirname(os.path.abspath(data_dir)), '*.latt')))
+    latt_file = candidates[0] if candidates else None
+
+with h5py.File(aperp_files[0], 'r') as f:
+    lambda_w = float(f['runInfo'].attrs.get('lambda_w', 0.0275))
+
+latt_elements, latt_z_total = [], 0.0
+if latt_file and os.path.exists(latt_file):
+    latt_elements, latt_z_total = parse_lattice(latt_file, lambda_w)
+    print(f'Lattice: {len(latt_elements)} elements, total z = {latt_z_total:.3f} m',
+          flush=True)
+
+
+# ── initial data ──────────────────────────────────────────────────────────────
+xf0, yf0, attrs0 = load_field_1d(aperp_files[0])
+s0, intens0       = temporal_profile(xf0, yf0, attrs0)
+omega0, spec0     = spectral_profile(xf0, yf0, attrs0)
+
+# Initial electron phase space
+_elec0 = _elec_file_for(0)
+if _elec0:
+    z2_ps0, dgam0 = load_electrons(_elec0, attrs0)
+else:
+    z2_ps0, dgam0 = np.array([0.0]), np.array([0.0])
+
+# Initial current profile
+_int0 = _closest_int_file(z_vals[0])
+if _int0:
+    curr_x0, curr_A0 = load_current(_int0, attrs0)
+else:
+    curr_x0, curr_A0 = np.array([0.0]), np.array([0.0])
+
+# One-cycle length in µm  (resonant wavelength = 4π·ρ·Lc)
+_rho = float(attrs0['rho'])
+_Lc  = float(attrs0['Lc'])
+cycle_len_um = 4.0 * np.pi * _rho * _Lc * 1e6
+
+# Default phase-space x_range: one cycle centred on particle centroid
+_z_center = float(np.median(z2_ps0)) if len(z2_ps0) > 0 else float(np.mean(s0))
+ps_xrange = Range1d(
+    start=_z_center - cycle_len_um / 2,
+    end  =_z_center + cycle_len_um / 2,
+)
+
+# Initial phase-space y-range from particles inside the starting window
+def _yrange_from_data(x_arr, y_arr, x0, x1):
+    """Return (ylo, yhi) with 5 % padding for particles in [x0, x1]."""
+    if len(x_arr) == 0:
+        return -0.05, 0.05
+    mask = (x_arr >= x0) & (x_arr <= x1)
+    y_vis = y_arr[mask] if np.any(mask) else y_arr
+    if len(y_vis) == 0:
+        return -0.05, 0.05
+    rng = float(np.max(y_vis)) - float(np.min(y_vis))
+    pad = 0.05 * rng if rng > 0 else 1e-4
+    return float(np.min(y_vis)) - pad, float(np.max(y_vis)) + pad
+
+_py0, _py1 = _yrange_from_data(z2_ps0, dgam0, ps_xrange.start, ps_xrange.end)
+ps_yrange = Range1d(start=_py0, end=_py1)
+
+
+# ── figures ───────────────────────────────────────────────────────────────────
+TOOLS = 'pan,wheel_zoom,box_zoom,reset,save'
+PW    = 1000   # total plot width
+TW    = PW // 3 - 10   # width of each top panel
+HW    = PW // 2 - 10   # width of each half-width panel
+
+src_intens   = ColumnDataSource(dict(x=s0.tolist(),     y=intens0.tolist()))
+src_spec_lin = ColumnDataSource(dict(x=omega0.tolist(), y=spec0.tolist()))
+spec0_log = np.where(spec0 > 0, spec0, 1e-30)
+src_spec_log = ColumnDataSource(dict(x=omega0.tolist(), y=spec0_log.tolist()))
+
+p_intens = figure(title='Temporal intensity  (cycle-avg)',
+                  x_axis_label='ct − z  (µm)',
+                  y_axis_label='Intensity  (W m⁻²)',
+                  width=TW, height=320, tools=TOOLS)
+p_intens.line('x', 'y', source=src_intens, color='royalblue', line_width=1.5)
+
+_spec_ref = Span(location=1.0, dimension='height',
+                 line_color='red', line_dash='dashed', line_width=1)
+_spec_ref2 = Span(location=1.0, dimension='height',
+                  line_color='red', line_dash='dashed', line_width=1)
+
+p_spec = figure(title='Spectral intensity  (linear)',
+                x_axis_label='ω / ωᵣ',
+                y_axis_label='Intensity  (a.u.)',
+                width=TW, height=320, tools=TOOLS)
+p_spec.line('x', 'y', source=src_spec_lin, color='darkorange', line_width=1.5)
+p_spec.add_layout(_spec_ref)
+
+p_spec_log = figure(title='Spectral intensity  (log)',
+                    x_axis_label='ω / ωᵣ',
+                    y_axis_label='Intensity  (a.u.)',
+                    x_range=p_spec.x_range,
+                    width=TW, height=320, tools=TOOLS,
+                    y_axis_type='log')
+p_spec_log.line('x', 'y', source=src_spec_log, color='darkorange', line_width=1.5)
+p_spec_log.add_layout(_spec_ref2)
+
+
+# ── current profile panel ─────────────────────────────────────────────────────
+src_curr = ColumnDataSource(dict(x=curr_x0.tolist(), y=curr_A0.tolist()))
+
+p_current = figure(title='Beam current  (drag green window → moves phase-space view)',
+                   x_axis_label='ct − z  (µm)',
+                   y_axis_label='Current  (A)',
+                   x_range=p_intens.x_range,   # shares field x-axis
+                   width=HW, height=280, tools='wheel_zoom,box_zoom,reset,save')
+p_current.line('x', 'y', source=src_curr, color='steelblue', line_width=1.5)
+
+# RangeTool: draggable/resizable box that directly drives ps_xrange
+range_tool = RangeTool(x_range=ps_xrange)
+range_tool.overlay.fill_color  = 'green'
+range_tool.overlay.fill_alpha  = 0.12
+range_tool.overlay.line_color  = 'green'
+range_tool.overlay.line_width  = 1.2
+p_current.add_tools(range_tool)
+
+
+# ── electron phase-space panel ────────────────────────────────────────────────
+src_phase = ColumnDataSource(dict(x=z2_ps0.tolist(), y=dgam0.tolist()))
+
+p_phase = figure(title='Electron phase space  (one-cycle zoom)',
+                 x_axis_label='ct − z  (µm)',
+                 y_axis_label='Δγ / ⟨γ⟩',
+                 x_range=ps_xrange,
+                 y_range=ps_yrange,
+                 width=HW, height=280, tools=TOOLS)
+p_phase.scatter('x', 'y', source=src_phase,
+                color='tomato', size=1.5, alpha=0.5)
+
+
+def _rescale_ps_y():
+    """Rescale the phase-space y-axis to particles inside the current x window."""
+    x = np.array(src_phase.data['x'])
+    y = np.array(src_phase.data['y'])
+    lo, hi = _yrange_from_data(x, y, ps_xrange.start, ps_xrange.end)
+    ps_yrange.start = lo
+    ps_yrange.end   = hi
+
+
+def _ps_range_cb(attr, old, new):
+    _rescale_ps_y()
+
+ps_xrange.on_change('start', _ps_range_cb)
+ps_xrange.on_change('end',   _ps_range_cb)
+
+
+# ── power vs z plot ───────────────────────────────────────────────────────────
+ylo = float(np.nanmin(pow_W)) if len(pow_W) else 1e-3
+yhi = float(np.nanmax(pow_W)) if len(pow_W) else 1e10
+
+p_power = figure(title='Power vs z',
+                 x_axis_label='z (m)', y_axis_label='Power (W)',
+                 width=PW, height=220, tools=TOOLS, y_axis_type='log')
+if len(pow_z):
+    src_pow = ColumnDataSource(dict(x=pow_z.tolist(), y=pow_W.tolist()))
+    p_power.line('x', 'y', source=src_pow, color='royalblue', line_width=1.5)
+
+src_vline = ColumnDataSource(dict(x0=[z_vals[0]], y0=[ylo],
+                                  x1=[z_vals[0]], y1=[yhi]))
+p_power.segment('x0', 'y0', 'x1', 'y1', source=src_vline,
+                color='red', line_dash='dashed', line_width=1.5)
+
+# lattice diagram
+p_latt = figure(title='Lattice',
+                x_axis_label='z (m)',
+                x_range=p_power.x_range,
+                width=PW, height=90, tools='pan,reset',
+                y_range=(-0.05, 1.05))
+p_latt.yaxis.visible = False
+p_latt.ygrid.visible = False
+p_latt.xgrid.visible = False
+
+if latt_elements:
+    un_x, un_y, un_w, un_h     = [], [], [], []
+    dr_x, dr_y, dr_w, dr_h     = [], [], [], []
+    ch_x, ch_y, ch_w, ch_h     = [], [], [], []
+    ch_x0, ch_y0, ch_x1, ch_y1 = [], [], [], []   # zero-length chicanes as lines
+    qu_x0, qu_y0, qu_x1, qu_y1 = [], [], [], []
+
+    for typ, zs, L in latt_elements:
+        if typ == 'UN':
+            un_x.append(zs + L/2); un_y.append(0.5)
+            un_w.append(L);        un_h.append(0.9)
+        elif typ == 'DR' and L > 0:
+            dr_x.append(zs + L/2); dr_y.append(0.5)
+            dr_w.append(L);        dr_h.append(0.5)
+        elif typ == 'CH':
+            if L > 0:
+                ch_x.append(zs + L/2); ch_y.append(0.5)
+                ch_w.append(L);        ch_h.append(0.7)
+            else:
+                ch_x0.append(zs); ch_y0.append(0.05)
+                ch_x1.append(zs); ch_y1.append(0.95)
+        elif typ == 'QU':
+            qu_x0.append(zs); qu_y0.append(0.05)
+            qu_x1.append(zs); qu_y1.append(0.95)
+
+    if dr_x:
+        p_latt.rect(dr_x, dr_y, dr_w, dr_h, color='#CCCCCC',
+                    line_color=None, alpha=0.6, legend_label='Drift')
+    if un_x:
+        p_latt.rect(un_x, un_y, un_w, un_h, color='#2176AE',
+                    line_color='white', line_width=0.5, legend_label='Undulator')
+    if ch_x:
+        p_latt.rect(ch_x, ch_y, ch_w, ch_h, color='#E87D2B',
+                    line_color=None, legend_label='Chicane')
+    if ch_x0:
+        p_latt.segment(ch_x0, ch_y0, ch_x1, ch_y1, color='#E87D2B',
+                       line_width=2.5, legend_label='Chicane')
+    if qu_x0:
+        p_latt.segment(qu_x0, qu_y0, qu_x1, qu_y1, color='#D62839',
+                       line_width=2, legend_label='Quad')
+
+    p_latt.legend.orientation = 'horizontal'
+    p_latt.legend.label_text_font_size = '9pt'
+    p_latt.legend.spacing = 10
+    p_latt.legend.padding = 4
+    p_latt.add_layout(p_latt.legend[0], 'below')
+
+src_lmark = ColumnDataSource(dict(x0=[z_vals[0]], y0=[0.0],
+                                  x1=[z_vals[0]], y1=[1.0]))
+p_latt.segment('x0', 'y0', 'x1', 'y1', source=src_lmark,
+               color='red', line_dash='dashed', line_width=1.5)
+
+
+# ── status + slider ───────────────────────────────────────────────────────────
+def _status_html(idx):
+    return (f'<span style="font-size:13px"><b>Step {idx+1}/{n_files}</b>'
+            f' &nbsp;|&nbsp; file step {step_num(aperp_files[idx])}'
+            f' &nbsp;|&nbsp; z = {z_vals[idx]:.4f} m</span>')
+
+status = Div(text=_status_html(0), width=PW)
+slider = Slider(start=0, end=n_files - 1, value=0, step=1,
+                title=f'z = {z_vals[0]:.3f} m', width=PW)
+
+
+def update(attr, old, new):
+    idx = int(slider.value)
+    xf, yf, attrs = load_field_1d(aperp_files[idx])
+
+    s, intens = temporal_profile(xf, yf, attrs)
+    omega, spec = spectral_profile(xf, yf, attrs)
+
+    spec_log = np.where(spec > 0, spec, 1e-30)
+    src_intens.data   = dict(x=s.tolist(),         y=intens.tolist())
+    src_spec_lin.data = dict(x=omega.tolist(),      y=spec.tolist())
+    src_spec_log.data = dict(x=omega.tolist(),      y=spec_log.tolist())
+
+    # Electron phase space
+    ep = _elec_file_for(idx)
+    if ep:
+        z2_um, dgam = load_electrons(ep, attrs)
+        src_phase.data = dict(x=z2_um.tolist(), y=dgam.tolist())
+    else:
+        src_phase.data = dict(x=[], y=[])
+    _rescale_ps_y()
+
+    # Current profile
+    ip = _closest_int_file(z_vals[idx])
+    if ip:
+        cx, cy = load_current(ip, attrs)
+        src_curr.data = dict(x=cx.tolist(), y=cy.tolist())
+    else:
+        src_curr.data = dict(x=[], y=[])
+
+    z = z_vals[idx]
+    src_vline.data = dict(x0=[z], y0=[ylo], x1=[z], y1=[yhi])
+    src_lmark.data = dict(x0=[z], y0=[0.0], x1=[z], y1=[1.0])
+
+    slider.title = f'z = {z:.3f} m'
+    status.text  = _status_html(idx)
+
+
+slider.on_change('value', update)
+
+# ── layout ────────────────────────────────────────────────────────────────────
+curdoc().add_root(column(
+    status,
+    row(p_intens, p_spec, p_spec_log),
+    row(p_current, p_phase),
+    p_power,
+    p_latt,
+    slider,
+))
+curdoc().title = f'Puffin 1D Field Viewer — {basename}'

--- a/utilities/pyPlotting/viewField3D.py
+++ b/utilities/pyPlotting/viewField3D.py
@@ -17,10 +17,21 @@ import sys, os, glob, re
 import numpy as np
 import h5py
 import matplotlib
-matplotlib.use('MacOSX')
+# MacOSX is the interactive default here, but honour MPLBACKEND so the script
+# still runs headless (CI, a Linux box, rendering a PNG).
+if not os.environ.get('MPLBACKEND'):
+    matplotlib.use('MacOSX')
 import matplotlib.pyplot as plt
 import matplotlib.gridspec as gridspec
 from matplotlib.widgets import Slider
+from matplotlib.ticker import LogLocator, ScalarFormatter
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import puffin_viz_theme as pvt
+import puffin_viz_data as pvd
+
+T = pvt.tokens()
+pvt.apply_matplotlib_style(T)
 
 # ── physical constants ──────────────────────────────────────────────────────
 C0   = 2.99792458e8
@@ -53,6 +64,19 @@ def load_aperp(path):
         aperp = f['aperp'][()]          # (2, nz2, ny, nx)
         attrs = dict(f['runInfo'].attrs)
     return aperp, attrs
+
+
+def clim(a):
+    """Colour limits, guarding the degenerate all-equal case.
+
+    The first dump of a run seeded from noise is identically zero. Passing
+    min == max to set_clim makes matplotlib pad the range symmetrically, so
+    a blank field lands mid-ramp — Inferno's midpoint is a strong crimson,
+    and an empty mesh comes out looking like a saturated one. Anchor to
+    [0, 1] instead, which puts "nothing" at the dark end of the ramp.
+    """
+    lo, hi = float(np.nanmin(a)), float(np.nanmax(a))
+    return (lo, hi) if hi > lo else (0.0, 1.0)
 
 
 # ── collect aperp files ───────────────────────────────────────────────────────
@@ -96,14 +120,19 @@ pow_z, pow_W = [], []
 if int_files:
     print(f'Loading power curve from {len(int_files)} integrated files...',
           end=' ', flush=True)
+    pow_attrs = {}
     for p in int_files:
         with h5py.File(p, 'r') as f:
-            ri = f['runInfo'].attrs
-            pow_z.append(float(ri['zTotal']))
-            # periodic mesh: mean over z2 nodes
-            pow_W.append(float(np.mean(f['powerSI'][()])))
+            pow_attrs = dict(f['runInfo'].attrs)
+            pow_z.append(float(pow_attrs['zTotal']))
+            # mean over z2 on a periodic mesh, peak on a temporal one — see
+            # puffin_viz_data.reduce_power
+            pow_W.append(pvd.reduce_power(f['powerSI'][()], pow_attrs)[0])
     pow_z = np.array(pow_z)
-    pow_W = np.array(pow_W)
+    # Zero power (the seed dump before any gain) has no place on a log axis:
+    # semilogy drops it silently, but it still drags the data minimum to 0 and
+    # breaks any range test downstream. Mask it, as the bokeh viewers do.
+    pow_W = np.where(np.array(pow_W) > 0, pow_W, np.nan)
     print('done')
 else:
     print('No integrated files found — power curve unavailable')
@@ -143,8 +172,30 @@ aperp0, attrs0 = load_aperp(aperp_files[0])
 iscale0 = intens_scale(attrs0)
 extent0 = xy_extent_mm(attrs0)
 
-field_img_data  = np.mean(np.sqrt(aperp0[0]**2 + aperp0[1]**2), axis=0)
-intens_img_data = np.mean(aperp0[0]**2 + aperp0[1]**2, axis=0) * iscale0
+def xy_reduce(aperp, iscale):
+    """Transverse |A| and intensity, collapsed over z2.
+
+    Periodic mesh: average, which is the honest cycle average. Temporal
+    mesh: the peak-power z2 node, because the window is mostly empty either
+    side of the pulse and averaging over it understates the peak intensity
+    by ~12x (fig7a) while smearing slices whose spot size varies along the
+    pulse. The bokeh viewer exposes this as a control; here it is automatic.
+    """
+    if pvd.mesh_is_periodic(attrs0):
+        return (np.mean(np.sqrt(aperp[0]**2 + aperp[1]**2), axis=0),
+                np.mean(aperp[0]**2 + aperp[1]**2, axis=0) * iscale,
+                None)
+    iz2 = int((aperp[0]**2 + aperp[1]**2).sum(axis=(1, 2)).argmax())
+    return (np.sqrt(aperp[0, iz2]**2 + aperp[1, iz2]**2),
+            (aperp[0, iz2]**2 + aperp[1, iz2]**2) * iscale,
+            iz2)
+
+
+def xy_label(iz2):
+    return 'z₂-avg' if iz2 is None else f'peak z₂ slice {iz2}'
+
+
+field_img_data, intens_img_data, _iz0 = xy_reduce(aperp0, iscale0)
 
 im_field  = ax_field.imshow(field_img_data,  origin='lower', extent=extent0,
                              cmap='inferno', aspect='equal')
@@ -153,34 +204,63 @@ im_intens = ax_intens.imshow(intens_img_data, origin='lower', extent=extent0,
 
 cb0 = fig.colorbar(im_field,  ax=ax_field,  fraction=0.046, pad=0.04)
 cb1 = fig.colorbar(im_intens, ax=ax_intens, fraction=0.046, pad=0.04)
-cb0.set_label('|A⊥|  (z₂-avg, scaled)')
-cb1.set_label('Intensity  (W m⁻²,  z₂-avg)')
+cb0.set_label('|A⊥|  (scaled)')
+cb1.set_label('Intensity  (W m⁻²)')
+for cb in (cb0, cb1):
+    cb.outline.set_visible(False)
+    cb.ax.tick_params(color=T['axis'], labelcolor=T['muted'], labelsize=9)
 
 ax_field.set_xlabel('x (mm)');  ax_field.set_ylabel('y (mm)')
 ax_intens.set_xlabel('x (mm)'); ax_intens.set_ylabel('y (mm)')
 ax_field.set_title('Field magnitude')
 ax_intens.set_title('Intensity')
+# the images carry their own scale; a grid over them is just noise
+for ax in (ax_field, ax_intens):
+    ax.grid(False)
 
 
 # ── power vs z plot ───────────────────────────────────────────────────────────
 
 if has_power:
-    ax_power.semilogy(pow_z, pow_W, color='royalblue', lw=1.4)
+    ax_power.semilogy(pow_z, pow_W, color=T['field'], lw=2.0)
     ax_power.set_xlabel('z (m)')
-    ax_power.set_ylabel('Power (W)')
-    ax_power.set_title('Power vs z')
+    ax_power.set_ylabel(pvd.power_axis_label(pow_attrs))
+    ax_power.set_title(pvd.power_title(pow_attrs))
     ax_power.set_xlim(pow_z[0], pow_z[-1])
-    ax_power.grid(True, which='both', ls='--', alpha=0.4)
-    vline = ax_power.axvline(x=z_vals[0], color='red', lw=1.5, ls='--')
+    # Major only: on a log axis 'both' draws nine minor lines per decade,
+    # which turns the panel into hatching.
+    ax_power.grid(True, which='major', ls='-', lw=0.8, color=T['grid'])
+    ax_power.grid(False, which='minor')
+    ax_power.set_axisbelow(True)
+
+    # A short run can span less than one decade, which leaves the log axis
+    # with a single labelled tick and nothing to read values against. Label
+    # the 2/3/5 minors in that case.
+    _lo, _hi = np.nanmin(pow_W), np.nanmax(pow_W)
+    if np.isfinite(_lo) and _lo > 0 and _hi / _lo < 100:
+        ax_power.yaxis.set_minor_locator(LogLocator(base=10, subs=(2, 3, 5)))
+        ax_power.yaxis.set_minor_formatter(ScalarFormatter())
+        ax_power.tick_params(axis='y', which='minor', labelsize=8)
+    for side in ('top', 'right'):
+        ax_power.spines[side].set_visible(False)
+    # current-z cue: chrome, not a series
+    vline = ax_power.axvline(x=z_vals[0], color=T['marker'], lw=2, ls='--')
 
 
 # ── slider (z in metres) ──────────────────────────────────────────────────────
 
+ax_slider.grid(False)
+# Slider draws its value text just outside its right edge, so give that text
+# room inside the figure rather than letting it run off the canvas.
+_sp = ax_slider.get_position()
+ax_slider.set_position([_sp.x0, _sp.y0, _sp.width * 0.92, _sp.height])
 slider = Slider(ax_slider, 'z (m)', 0, n_files - 1,
-                valinit=0, valstep=1, color='steelblue')
+                valinit=0, valstep=1, color=T['field'])
 slider.valtext.set_text(f'{z_vals[0]:.3f} m')
+slider.valtext.set_color(T['ink'])
+slider.label.set_color(T['ink2'])
 
-suptitle = fig.suptitle('', fontsize=11)
+suptitle = fig.suptitle('', fontsize=11, color=T['ink'])
 
 def update_suptitle(idx):
     suptitle.set_text(
@@ -197,11 +277,12 @@ def draw_step(idx):
     iscale = intens_scale(attrs)
     ext    = xy_extent_mm(attrs)
 
-    fi = np.mean(np.sqrt(aperp[0]**2 + aperp[1]**2), axis=0)
-    ii = np.mean(aperp[0]**2 + aperp[1]**2, axis=0) * iscale
+    fi, ii, iz2 = xy_reduce(aperp, iscale)
+    ax_field.set_title(f'Field magnitude  ({xy_label(iz2)})')
+    ax_intens.set_title(f'Intensity  ({xy_label(iz2)})')
 
-    im_field.set_data(fi);  im_field.set_extent(ext);  im_field.set_clim(fi.min(), fi.max())
-    im_intens.set_data(ii); im_intens.set_extent(ext); im_intens.set_clim(ii.min(), ii.max())
+    im_field.set_data(fi);  im_field.set_extent(ext);  im_field.set_clim(*clim(fi))
+    im_intens.set_data(ii); im_intens.set_extent(ext); im_intens.set_clim(*clim(ii))
 
     if has_power:
         vline.set_xdata([z_vals[idx], z_vals[idx]])

--- a/utilities/pyPlotting/viewField3D.py
+++ b/utilities/pyPlotting/viewField3D.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""
+Interactive viewer for Puffin 3D field output files (aperp_*.h5).
+
+Usage:
+    python viewField3D.py [data_dir] [basename]
+
+    data_dir  - directory containing aperp/integrated HDF5 files (default: .)
+    basename  - run name prefix (default: auto-detected)
+
+Controls:
+    Slider          - scrub through output steps; label shows z (m)
+    Left/Right keys - step backward / forward one file
+"""
+
+import sys, os, glob, re
+import numpy as np
+import h5py
+import matplotlib
+matplotlib.use('MacOSX')
+import matplotlib.pyplot as plt
+import matplotlib.gridspec as gridspec
+from matplotlib.widgets import Slider
+
+# ── physical constants ──────────────────────────────────────────────────────
+C0   = 2.99792458e8
+QE   = 1.60217653e-19
+EPS0 = 8.854187817e-12
+ME   = 9.1093826e-31
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def step_num(path):
+    m = re.search(r'_(\d+)\.h5$', path)
+    return int(m.group(1)) if m else 0
+
+
+def intens_scale(attrs):
+    return C0 * EPS0 * (attrs['gamma_r'] * ME * C0**2
+                        / (QE * attrs['kappa'] * attrs['Lg']))**2
+
+
+def xy_extent_mm(attrs):
+    dx = attrs['sLengthOfElmX'] * np.sqrt(attrs['Lg'] * attrs['Lc'])
+    dy = attrs['sLengthOfElmY'] * np.sqrt(attrs['Lg'] * attrs['Lc'])
+    nx, ny = int(attrs['nX']), int(attrs['nY'])
+    return [-nx/2*dx*1e3, nx/2*dx*1e3, -ny/2*dy*1e3, ny/2*dy*1e3]
+
+
+def load_aperp(path):
+    with h5py.File(path, 'r') as f:
+        aperp = f['aperp'][()]          # (2, nz2, ny, nx)
+        attrs = dict(f['runInfo'].attrs)
+    return aperp, attrs
+
+
+# ── collect aperp files ───────────────────────────────────────────────────────
+
+data_dir = sys.argv[1] if len(sys.argv) > 1 else '.'
+basename = sys.argv[2] if len(sys.argv) > 2 else None
+
+all_h5 = glob.glob(os.path.join(data_dir, '*_aperp_*.h5'))
+if not all_h5:
+    sys.exit(f'No aperp HDF5 files found in {data_dir}')
+
+if basename is None:
+    basename = re.sub(r'_aperp_\d+\.h5$', '',
+                      os.path.basename(sorted(all_h5, key=step_num)[0]))
+
+aperp_files = sorted(
+    glob.glob(os.path.join(data_dir, f'{basename}_aperp_*.h5')),
+    key=step_num)
+n_files = len(aperp_files)
+print(f'Found {n_files} aperp files  (basename="{basename}")')
+
+
+# ── pre-load z positions from aperp attrs (fast — no data read) ───────────────
+
+print('Scanning z positions...', end=' ', flush=True)
+z_vals = []
+for p in aperp_files:
+    with h5py.File(p, 'r') as f:
+        z_vals.append(float(f['runInfo'].attrs['zTotal']))
+z_vals = np.array(z_vals)
+print('done')
+
+
+# ── pre-load power curve from integrated files ────────────────────────────────
+
+int_files = sorted(
+    glob.glob(os.path.join(data_dir, f'{basename}_integrated_*.h5')),
+    key=step_num)
+
+pow_z, pow_W = [], []
+if int_files:
+    print(f'Loading power curve from {len(int_files)} integrated files...',
+          end=' ', flush=True)
+    for p in int_files:
+        with h5py.File(p, 'r') as f:
+            ri = f['runInfo'].attrs
+            pow_z.append(float(ri['zTotal']))
+            # periodic mesh: mean over z2 nodes
+            pow_W.append(float(np.mean(f['powerSI'][()])))
+    pow_z = np.array(pow_z)
+    pow_W = np.array(pow_W)
+    print('done')
+else:
+    print('No integrated files found — power curve unavailable')
+
+
+# ── figure layout ─────────────────────────────────────────────────────────────
+
+fig = plt.figure(figsize=(13, 8))
+has_power = len(pow_z) > 0
+
+if has_power:
+    gs = gridspec.GridSpec(
+        3, 2,
+        figure=fig,
+        height_ratios=[5, 3, 0.6],
+        hspace=0.45, wspace=0.35,
+        bottom=0.08, top=0.93, left=0.08, right=0.97)
+    ax_field  = fig.add_subplot(gs[0, 0])
+    ax_intens = fig.add_subplot(gs[0, 1])
+    ax_power  = fig.add_subplot(gs[1, :])
+    ax_slider = fig.add_subplot(gs[2, :])
+else:
+    gs = gridspec.GridSpec(
+        2, 2,
+        figure=fig,
+        height_ratios=[10, 0.6],
+        hspace=0.4, wspace=0.35,
+        bottom=0.1, top=0.93, left=0.08, right=0.97)
+    ax_field  = fig.add_subplot(gs[0, 0])
+    ax_intens = fig.add_subplot(gs[0, 1])
+    ax_slider = fig.add_subplot(gs[1, :])
+
+
+# ── initial field load ────────────────────────────────────────────────────────
+
+aperp0, attrs0 = load_aperp(aperp_files[0])
+iscale0 = intens_scale(attrs0)
+extent0 = xy_extent_mm(attrs0)
+
+field_img_data  = np.mean(np.sqrt(aperp0[0]**2 + aperp0[1]**2), axis=0)
+intens_img_data = np.mean(aperp0[0]**2 + aperp0[1]**2, axis=0) * iscale0
+
+im_field  = ax_field.imshow(field_img_data,  origin='lower', extent=extent0,
+                             cmap='inferno', aspect='equal')
+im_intens = ax_intens.imshow(intens_img_data, origin='lower', extent=extent0,
+                              cmap='inferno', aspect='equal')
+
+cb0 = fig.colorbar(im_field,  ax=ax_field,  fraction=0.046, pad=0.04)
+cb1 = fig.colorbar(im_intens, ax=ax_intens, fraction=0.046, pad=0.04)
+cb0.set_label('|A⊥|  (z₂-avg, scaled)')
+cb1.set_label('Intensity  (W m⁻²,  z₂-avg)')
+
+ax_field.set_xlabel('x (mm)');  ax_field.set_ylabel('y (mm)')
+ax_intens.set_xlabel('x (mm)'); ax_intens.set_ylabel('y (mm)')
+ax_field.set_title('Field magnitude')
+ax_intens.set_title('Intensity')
+
+
+# ── power vs z plot ───────────────────────────────────────────────────────────
+
+if has_power:
+    ax_power.semilogy(pow_z, pow_W, color='royalblue', lw=1.4)
+    ax_power.set_xlabel('z (m)')
+    ax_power.set_ylabel('Power (W)')
+    ax_power.set_title('Power vs z')
+    ax_power.set_xlim(pow_z[0], pow_z[-1])
+    ax_power.grid(True, which='both', ls='--', alpha=0.4)
+    vline = ax_power.axvline(x=z_vals[0], color='red', lw=1.5, ls='--')
+
+
+# ── slider (z in metres) ──────────────────────────────────────────────────────
+
+slider = Slider(ax_slider, 'z (m)', 0, n_files - 1,
+                valinit=0, valstep=1, color='steelblue')
+slider.valtext.set_text(f'{z_vals[0]:.3f} m')
+
+suptitle = fig.suptitle('', fontsize=11)
+
+def update_suptitle(idx):
+    suptitle.set_text(
+        f'Step {idx+1}/{n_files}  |  file step {step_num(aperp_files[idx])}'
+        f'  |  z = {z_vals[idx]:.4f} m')
+
+update_suptitle(0)
+
+current = [0]
+
+
+def draw_step(idx):
+    aperp, attrs = load_aperp(aperp_files[idx])
+    iscale = intens_scale(attrs)
+    ext    = xy_extent_mm(attrs)
+
+    fi = np.mean(np.sqrt(aperp[0]**2 + aperp[1]**2), axis=0)
+    ii = np.mean(aperp[0]**2 + aperp[1]**2, axis=0) * iscale
+
+    im_field.set_data(fi);  im_field.set_extent(ext);  im_field.set_clim(fi.min(), fi.max())
+    im_intens.set_data(ii); im_intens.set_extent(ext); im_intens.set_clim(ii.min(), ii.max())
+
+    if has_power:
+        vline.set_xdata([z_vals[idx], z_vals[idx]])
+
+    slider.valtext.set_text(f'{z_vals[idx]:.3f} m')
+    update_suptitle(idx)
+    fig.canvas.draw_idle()
+
+
+def on_slider(val):
+    idx = int(slider.val)
+    current[0] = idx
+    draw_step(idx)
+
+slider.on_changed(on_slider)
+
+
+def on_key(event):
+    idx = current[0]
+    if   event.key == 'right': idx = min(idx + 1, n_files - 1)
+    elif event.key == 'left':  idx = max(idx - 1, 0)
+    else: return
+    current[0] = idx
+    slider.set_val(idx)
+
+fig.canvas.mpl_connect('key_press_event', on_key)
+
+draw_step(0)
+plt.show()

--- a/utilities/pyPlotting/viewField3D_bokeh.py
+++ b/utilities/pyPlotting/viewField3D_bokeh.py
@@ -15,9 +15,16 @@ import h5py
 
 from bokeh.plotting import figure, curdoc
 from bokeh.models import (ColumnDataSource, Slider, LinearColorMapper,
-                           ColorBar, Div, Segment)
+                           ColorBar, Div, Segment, HoverTool, CrosshairTool,
+                           Range1d, PrintfTickFormatter, RadioButtonGroup,
+                           Span)
 from bokeh.layouts import column, row
 from bokeh.palettes import Inferno256
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import puffin_viz_theme as pvt
+import puffin_viz_player as pvp
+import puffin_viz_data as pvd
 
 # ── physical constants ──────────────────────────────────────────────────────
 C0   = 2.99792458e8
@@ -36,11 +43,12 @@ def intens_scale(attrs):
     return C0 * EPS0 * (attrs['gamma_r'] * ME * C0**2
                         / (QE * attrs['kappa'] * attrs['Lg']))**2
 
-def xy_extent_mm(attrs):
-    dx = attrs['sLengthOfElmX'] * np.sqrt(attrs['Lg'] * attrs['Lc'])
-    dy = attrs['sLengthOfElmY'] * np.sqrt(attrs['Lg'] * attrs['Lc'])
+def xy_extent(attrs, u):
+    """(xmin, xmax, ymin, ymax) in u's transverse units."""
+    dx = float(attrs['sLengthOfElmX']) * u.xy_mul
+    dy = float(attrs['sLengthOfElmY']) * u.xy_mul
     nx, ny = int(attrs['nX']), int(attrs['nY'])
-    return -nx/2*dx*1e3, nx/2*dx*1e3, -ny/2*dy*1e3, ny/2*dy*1e3
+    return -nx/2*dx, nx/2*dx, -ny/2*dy, ny/2*dy
 
 def load_aperp(path):
     with h5py.File(path, 'r') as f:
@@ -48,10 +56,51 @@ def load_aperp(path):
         attrs = dict(f['runInfo'].attrs)
     return aperp, attrs
 
-def field_and_intens(aperp, iscale):
-    mag = np.mean(np.sqrt(aperp[0]**2 + aperp[1]**2), axis=0)  # z2-avg |A|
-    ixy = np.mean(aperp[0]**2 + aperp[1]**2, axis=0) * iscale  # z2-avg intensity
+def slice_power(aperp):
+    """Transverse-integrated |A|^2 per z2 node — the pulse profile in z2."""
+    return (aperp[0]**2 + aperp[1]**2).sum(axis=(1, 2))
+
+
+def peak_slice(aperp):
+    """Index of the z2 node carrying the most power."""
+    return int(slice_power(aperp).argmax())
+
+
+def field_and_intens(aperp, iscale, iz2=None):
+    """Transverse |A| and intensity, either at one z2 node or averaged.
+
+    iz2 = None averages over the whole z2 window. That is a true cycle
+    average on a periodic mesh, but on a temporal mesh the window is mostly
+    empty either side of the pulse — 70% of nodes sit below 1% of peak in the
+    fig7a example — so the average understates the peak intensity by ~12x and
+    smears together slices whose spot size varies by ~50% along the pulse.
+    Pass an index to see one z2 node instead.
+    """
+    if iz2 is None:
+        mag = np.mean(np.sqrt(aperp[0]**2 + aperp[1]**2), axis=0)
+        ixy = np.mean(aperp[0]**2 + aperp[1]**2, axis=0) * iscale
+    else:
+        iz2 = int(np.clip(iz2, 0, aperp.shape[1] - 1))
+        mag = np.sqrt(aperp[0, iz2]**2 + aperp[1, iz2]**2)
+        ixy = (aperp[0, iz2]**2 + aperp[1, iz2]**2) * iscale
     return mag, ixy
+
+
+# Active unit system. UNITS is rebuilt whenever the toggle changes; every
+# axis label and factor is read from it rather than hard-coded.
+UNITS = None
+
+
+def clim(a):
+    """Colour-mapper limits, guarding the degenerate all-equal case.
+
+    The first dump of a run seeded from noise is identically zero, and
+    low == high makes the mapper put every cell at the same point on the
+    ramp — mid-Inferno is a strong crimson, so an empty mesh reads as a
+    saturated one. Anchor to [0, 1] so "nothing" sits at the dark end.
+    """
+    lo, hi = float(np.nanmin(a)), float(np.nanmax(a))
+    return (lo, hi) if hi > lo else (0.0, 1.0)
 
 
 # ── parse arguments ───────────────────────────────────────────────────────────
@@ -92,19 +141,56 @@ print('done', flush=True)
 int_files = sorted(
     glob.glob(os.path.join(data_dir, f'{basename}_integrated_*.h5')),
     key=step_num)
-pow_z, pow_W = np.array([]), np.array([])
+pow_z = np.array([])
+int_z_vals = np.array([])
+pow_attrs = {}
+# Both unit systems are built up front: toggling units must not re-read the
+# whole integrated set (316 files on the fig7a run).
+POW_W = {pvd.SCALED: np.array([]), pvd.SI: np.array([])}
+POW_J = {pvd.SCALED: np.array([]), pvd.SI: np.array([])}
 if int_files:
     print(f'Loading power curve ({len(int_files)} files)...', end=' ', flush=True)
-    pz, pw = [], []
+    pz = []
+    acc = {pvd.SCALED: ([], []), pvd.SI: ([], [])}
     for p in int_files:
         with h5py.File(p, 'r') as f:
-            pz.append(float(f['runInfo'].attrs['zTotal']))
-            pw.append(float(np.mean(f['powerSI'][()])))
+            pow_attrs = dict(f['runInfo'].attrs)
+            pz.append(float(pow_attrs['zTotal']))
+            for mode in (pvd.SCALED, pvd.SI):
+                u = pvd.Units(pow_attrs, mode)
+                arr = f[u.power_key][()]
+                # mean over z2 on a periodic mesh, peak on a temporal one —
+                # see puffin_viz_data.reduce_power
+                acc[mode][0].append(pvd.reduce_power(arr, pow_attrs)[0])
+                acc[mode][1].append(u.energy(arr, pow_attrs))
     pow_z = np.array(pz)
-    pow_W = np.array(pw)
-    # guard against zeros on log axis
-    pow_W = np.where(pow_W > 0, pow_W, np.nan)
-    print('done', flush=True)
+    for mode in (pvd.SCALED, pvd.SI):
+        w, j = acc[mode]
+        # guard against zeros on log axis
+        POW_W[mode] = np.where(np.array(w) > 0, w, np.nan)
+        POW_J[mode] = np.where(np.array(j) > 0, j, np.nan)
+    int_z_vals = pow_z.copy()
+    print(f'done  ({pvd.reduce_power(np.array([1.0]), pow_attrs)[1]})', flush=True)
+
+
+def _closest_int_file(z):
+    """Integrated file whose z is nearest z, or None.
+
+    The integrated files are written on their own (finer) cadence, so they do
+    not line up with the aperp steps the slider indexes.
+    """
+    if len(int_z_vals) == 0:
+        return None
+    return int_files[int(np.argmin(np.abs(int_z_vals - z)))]
+
+
+def load_power_profile(int_path, u):
+    """(z2 axis, power) — the temporal profile at one z, in u's units."""
+    with h5py.File(int_path, 'r') as f:
+        p = f[u.power_key][()]
+        a = dict(f['runInfo'].attrs)
+        b = pvd.mesh_bounds(f)
+    return u.z2_axis(len(p), a, b), p
 
 
 # ── lattice ───────────────────────────────────────────────────────────────────
@@ -129,12 +215,29 @@ def parse_lattice(latt_path, lw):
     return elements, z
 
 # find lattice file
-if latt_arg:
-    latt_file = latt_arg
-else:
+def find_lattice(latt_arg, data_dir):
+    """Resolve the lattice file, falling back to auto-detection.
+
+    An explicit path that does not exist is a typo, not a request for no
+    lattice — warn instead of silently drawing an empty lattice panel, which
+    looks like the run simply had no elements.
+    """
+    if latt_arg:
+        if os.path.exists(latt_arg):
+            return latt_arg
+        print(f'WARNING: lattice file not found: {latt_arg}'
+              '  — falling back to auto-detection', flush=True)
     candidates = (glob.glob(os.path.join(data_dir, '*.latt')) +
-                  glob.glob(os.path.join(os.path.dirname(os.path.abspath(data_dir)), '*.latt')))
-    latt_file = candidates[0] if candidates else None
+                  glob.glob(os.path.join(
+                      os.path.dirname(os.path.abspath(data_dir)), '*.latt')))
+    if candidates:
+        return candidates[0]
+    print('WARNING: no .latt file found — lattice panel will be empty',
+          flush=True)
+    return None
+
+
+latt_file = find_lattice(latt_arg, data_dir)
 
 with h5py.File(aperp_files[0], 'r') as f:
     lambda_w = float(f['runInfo'].attrs.get('lambda_w', 0.0275))
@@ -148,58 +251,234 @@ if latt_file and os.path.exists(latt_file):
 # ── initial field data ────────────────────────────────────────────────────────
 aperp0, attrs0 = load_aperp(aperp_files[0])
 iscale0 = intens_scale(attrs0)
-xmin, xmax, ymin, ymax = xy_extent_mm(attrs0)
-fi0, ii0 = field_and_intens(aperp0, iscale0)
+
+UNITS = pvd.Units(attrs0, pvd.SI)     # default to SI; toggle switches it
+NZ2 = int(aperp0.shape[1])
+z2_ax = UNITS.z2_axis(NZ2, attrs0)    # ct-z / z2 for the aperp mesh
+xmin, xmax, ymin, ymax = xy_extent(attrs0, UNITS)
+
+# How the x-y panels collapse z2. On a periodic mesh the window is one
+# radiation period and averaging is the honest cycle average; on a temporal
+# mesh it is mostly empty window, so track the peak-power slice instead.
+MODE_PEAK, MODE_MANUAL, MODE_AVG = 0, 1, 2
+xy_mode = MODE_AVG if pvd.mesh_is_periodic(attrs0) else MODE_PEAK
+xy_slice = peak_slice(aperp0)
+
+
+def _xy_index(aperp):
+    """z2 index the x-y panels should show, or None for the average."""
+    if xy_mode == MODE_AVG:
+        return None
+    if xy_mode == MODE_PEAK:
+        return peak_slice(aperp)
+    return xy_slice
+
+
+def _xy_suffix(iz2):
+    if iz2 is None:
+        return '  (z₂-avg)'
+    # z2_unit is empty in scaled units, where the axis is dimensionless
+    at = f'{z2_ax[iz2]:.4g}'
+    if UNITS.z2_unit:
+        at += f' {UNITS.z2_unit}'
+    return f'  (z₂ slice {iz2} @ {at})'
+
+
+_i0 = _xy_index(aperp0)
+fi0, ii0 = field_and_intens(aperp0, UNITS.intensity_factor(iscale0), _i0)
 
 
 # ── figures ───────────────────────────────────────────────────────────────────
 TOOLS = 'pan,wheel_zoom,box_zoom,reset,save'
-IW, IH = 430, 390   # image panel size
+IW, IH = 470, 390   # image panel size (wide enough for the colorbar labels)
 
-mapper_f = LinearColorMapper(palette=Inferno256, low=float(fi0.min()), high=float(fi0.max()))
-mapper_i = LinearColorMapper(palette=Inferno256, low=float(ii0.min()), high=float(ii0.max()))
+# Colorbar values are tiny (|A|) or huge (W/m²), so they always carry an
+# exponent. "%.1e" keeps that exponent while staying short enough not to be
+# clipped at the panel edge — the default "6.000e-4" is not.
+CB_FMT = PrintfTickFormatter(format='%.1e')
+SLIDER_INSET = 90   # left margin keeping the slider off the window edge
+
+T = pvt.tokens()
+curdoc().theme = pvt.bokeh_theme(T)
+pvt.apply_page_style(curdoc(), T)
+
+_lo_f, _hi_f = clim(fi0)
+_lo_i, _hi_i = clim(ii0)
+mapper_f = LinearColorMapper(palette=Inferno256, low=_lo_f, high=_hi_f)
+mapper_i = LinearColorMapper(palette=Inferno256, low=_lo_i, high=_hi_i)
 
 src_field  = ColumnDataSource(dict(image=[fi0],  x=[xmin], y=[ymin],
                                    dw=[xmax-xmin], dh=[ymax-ymin]))
 src_intens = ColumnDataSource(dict(image=[ii0], x=[xmin], y=[ymin],
                                    dw=[xmax-xmin], dh=[ymax-ymin]))
 
-p_field = figure(title='Field magnitude  (z₂-avg, scaled)',
-                 x_axis_label='x (mm)', y_axis_label='y (mm)',
-                 width=IW, height=IH, tools=TOOLS)
-p_field.image('image', source=src_field, x='x', y='y', dw='dw', dh='dh',
-              color_mapper=mapper_f)
+# Sequential magnitude, so a perceptually-uniform ramp: Inferno is monotonic
+# in lightness and CVD-safe (it is not a jet-style rainbow), and it is what
+# readers of an FEL transverse profile expect.
+# toolbar above, not overlaid: these panels carry a colorbar on the right,
+# and the default in-frame toolbar sits straight on top of its tick labels.
+p_field = figure(title='Field magnitude' + _xy_suffix(_i0),
+                 x_axis_label=UNITS.x_label, y_axis_label=UNITS.y_label,
+                 width=IW, height=IH, tools=TOOLS, toolbar_location='above')
+_r = p_field.image('image', source=src_field, x='x', y='y', dw='dw', dh='dh',
+                   color_mapper=mapper_f)
+p_field.add_tools(HoverTool(renderers=[_r], tooltips=[
+    ('x', '$x{0.00} mm'), ('y', '$y{0.00} mm'), ('|A⊥|', '@image{0.000}')]))
 p_field.add_layout(ColorBar(color_mapper=mapper_f, label_standoff=8,
-                             width=12, title='|A⊥|'), 'right')
+                             width=12, title='|A⊥|',
+                             formatter=CB_FMT), 'right')
 
-p_intens = figure(title='Intensity  (z₂-avg)',
-                  x_axis_label='x (mm)', y_axis_label='y (mm)',
-                  width=IW, height=IH, tools=TOOLS)
-p_intens.image('image', source=src_intens, x='x', y='y', dw='dw', dh='dh',
-               color_mapper=mapper_i)
-p_intens.add_layout(ColorBar(color_mapper=mapper_i, label_standoff=8,
-                              width=12, title='W/m²'), 'right')
+p_intens = figure(title='Intensity' + _xy_suffix(_i0),
+                  x_axis_label=UNITS.x_label, y_axis_label=UNITS.y_label,
+                  width=IW, height=IH, tools=TOOLS, toolbar_location='above')
+_r = p_intens.image('image', source=src_intens, x='x', y='y', dw='dw', dh='dh',
+                    color_mapper=mapper_i)
+p_intens.add_tools(HoverTool(renderers=[_r], tooltips=[
+    ('x', '$x{0.00} mm'), ('y', '$y{0.00} mm'), ('I', '@image{0.00e+0} W/m²')]))
+cbar_i = ColorBar(color_mapper=mapper_i, label_standoff=8,
+                  width=12, title=UNITS.intens_label, formatter=CB_FMT)
+p_intens.add_layout(cbar_i, 'right')
 
 # power vs z
 PW = IW * 2 + 20
-p_power = figure(title='Power vs z', x_axis_label='z (m)', y_axis_label='Power (W)',
-                 width=PW, height=220, tools=TOOLS, y_axis_type='log')
-if len(pow_z):
-    src_pow = ColumnDataSource(dict(x=pow_z.tolist(), y=pow_W.tolist()))
-    p_power.line('x', 'y', source=src_pow, color='royalblue', line_width=1.5)
+# Series for the active unit system; apply_units() swaps these on toggle.
+pow_W = POW_W[UNITS.mode]
+pow_J = POW_J[UNITS.mode]
+
+# Range first: it decides the axis type, so it has to be known before the
+# figure is built. Every dump can be zero power (a seeded run that has not
+# gained yet) and those are masked to NaN above — so check for a finite
+# value, not just a non-empty array, or nanmin warns and returns NaN.
+if len(pow_W) and np.any(np.isfinite(pow_W)):
     ylo = float(np.nanmin(pow_W)); yhi = float(np.nanmax(pow_W))
 else:
     ylo, yhi = 1e-3, 1e10
 
-src_vline = ColumnDataSource(dict(x0=[z_vals[0]], y0=[ylo],
-                                  x1=[z_vals[0]], y1=[yhi]))
+# Log only when the curve actually spans decades. Start-to-saturation gain
+# does and needs it; a short or already-saturated run spans well under a
+# decade, and a log axis then crowds every tick into the top of the frame
+# where the labels overlap and cannot be read.
+_pow_decades = (yhi / ylo) if ylo > 0 else float('inf')
+_pow_axis = 'log' if _pow_decades >= 100 else 'linear'
+
+# Span the simulated z, not the lattice. p_latt shares this range, so a run
+# that covers only the head of a long lattice (a truncated test case) would
+# otherwise squash its whole power curve into a sliver at x=0 to make room
+# for 20 m of undulators that were never simulated.
+_zs = np.concatenate([a for a in (z_vals, pow_z) if len(a)]) * UNITS.z_mul
+_zpad = max((float(_zs.max()) - float(_zs.min())) * 0.02, 1e-6)
+_zrange = Range1d(start=float(_zs.min()) - _zpad, end=float(_zs.max()) + _zpad)
+
+HW = PW // 2 - 5   # half-width, for the peak/energy pair
+
+p_power = figure(title=UNITS.power_title(pow_attrs),
+                 x_axis_label=UNITS.z_label,
+                 y_axis_label=UNITS.power_label,
+                 x_range=_zrange,
+                 width=HW, height=230, tools=TOOLS, y_axis_type=_pow_axis)
+if len(pow_z):
+    src_pow = ColumnDataSource(dict(x=(pow_z*UNITS.z_mul).tolist(),
+                                    y=pow_W.tolist()))
+    _r = p_power.line('x', 'y', source=src_pow, color=T['field'], line_width=2)
+    p_power.add_tools(
+        HoverTool(renderers=[_r], mode='vline', attachment='above',
+                  tooltips=[('z', '@x{0.000} m'),
+                            (pvd.reduce_power(np.array([1.0]), pow_attrs)[1],
+                             '@y{0.00e+0} W')]),
+        CrosshairTool(line_color=T['muted'], line_alpha=0.6, line_width=1))
+
+# ── energy vs z ───────────────────────────────────────────────────────────────
+# Peak power and energy answer different questions (how intense the spike is
+# vs how much light there is in total), so they get their own panels rather
+# than a second y-axis on one plot.
+if len(pow_J) and np.any(np.isfinite(pow_J)):
+    _elo, _ehi = float(np.nanmin(pow_J)), float(np.nanmax(pow_J))
+else:
+    _elo, _ehi = 1e-12, 1e-3
+_e_axis = 'log' if (_elo > 0 and _ehi / _elo >= 100) else 'linear'
+
+p_energy = figure(title=UNITS.energy_title(pow_attrs),
+                  x_axis_label=UNITS.z_label,
+                  y_axis_label=UNITS.energy_label,
+                  x_range=_zrange,
+                  width=HW, height=230, tools=TOOLS, y_axis_type=_e_axis)
+if len(pow_z):
+    src_en = ColumnDataSource(dict(x=(pow_z*UNITS.z_mul).tolist(),
+                                   y=pow_J.tolist()))
+    _r = p_energy.line('x', 'y', source=src_en, color=T['field'], line_width=2)
+    p_energy.add_tools(
+        HoverTool(renderers=[_r], mode='vline', attachment='above',
+                  tooltips=[('z', '@x{0.000} m'), ('E', '@y{0.000e+0} J')]),
+        CrosshairTool(line_color=T['muted'], line_alpha=0.6, line_width=1))
+
+src_evline = ColumnDataSource(dict(x0=[z_vals[0]*UNITS.z_mul], y0=[_elo],
+                                   x1=[z_vals[0]*UNITS.z_mul], y1=[_ehi]))
+p_energy.segment('x0', 'y0', 'x1', 'y1', source=src_evline,
+                 color=T['marker'], line_dash='dashed', line_width=2)
+
+# ── temporal profile: power vs ct-z at the current step ───────────────────────
+_ip0 = _closest_int_file(z_vals[0])
+if _ip0:
+    _tx0, _ty0 = load_power_profile(_ip0, UNITS)
+else:
+    _tx0, _ty0 = np.array([0.0]), np.array([0.0])
+src_tprof = ColumnDataSource(dict(x=_tx0.tolist(), y=_ty0.tolist()))
+
+p_tprof = figure(title='Temporal profile  (at this z)',
+                 x_axis_label=UNITS.z2_label, y_axis_label=UNITS.power_label,
+                 width=PW, height=250, tools=TOOLS)
+_r = p_tprof.line('x', 'y', source=src_tprof, color=T['field'], line_width=2)
+p_tprof.add_tools(
+    HoverTool(renderers=[_r], mode='vline', attachment='above',
+              tooltips=[('ct−z', '@x{0.00} µm'), ('P', '@y{0.00e+0} W')]),
+    CrosshairTool(line_color=T['muted'], line_alpha=0.6, line_width=1))
+
+# Marks which z2 node the x-y panels below are showing. It is a cursor into
+# the pulse, not data, so it wears the select hue.
+slice_span = Span(location=float(z2_ax[_i0]) if _i0 is not None else 0.0,
+                  dimension='height', line_color=T['select'],
+                  line_width=2, line_dash='dashed',
+                  visible=_i0 is not None)
+p_tprof.add_layout(slice_span)
+
+
+# ── x-y slice controls ────────────────────────────────────────────────────────
+xy_mode_btn = RadioButtonGroup(
+    labels=['Peak slice', 'Manual slice', 'z₂ average'],
+    active=xy_mode, width=330)
+
+xy_slice_sl = Slider(start=0, end=max(NZ2 - 1, 1), value=xy_slice, step=1,
+                     # PW less the inset, the mode buttons and the gaps —
+                     # a wider slider overflows the page and gets clipped.
+                     title='z₂ node', width=PW - SLIDER_INSET - 330 - 60,
+                     disabled=xy_mode != MODE_MANUAL,
+                     margin=(0, 10, 0, 14))
+
+xy_note = Div(text='', width=PW, margin=(0, 10, 6, SLIDER_INSET))
+
+
+def _xy_note_html(iz2):
+    if iz2 is None:
+        return (f'<span style="font-family:{pvt.FONT}; font-size:11px; '
+                f'color:{T["muted"]};">x-y panels average over all {NZ2} z₂ '
+                f'nodes — a true cycle average on a periodic mesh, but on a '
+                f'pulse it includes the empty window either side.</span>')
+    return (f'<span style="font-family:{pvt.FONT}; font-size:11px; '
+            f'color:{T["muted"]};">x-y panels show z₂ node {iz2} of {NZ2} '
+            f'at {UNITS.z2_label} = {z2_ax[iz2]:.4g} (dashed cursor above).</span>')
+
+
+xy_note.text = _xy_note_html(_i0)
+
+# The current-z cue is chrome, not a series: primary ink, dashed.
+src_vline = ColumnDataSource(dict(x0=[z_vals[0]*UNITS.z_mul], y0=[ylo],
+                                  x1=[z_vals[0]*UNITS.z_mul], y1=[yhi]))
 p_power.segment('x0', 'y0', 'x1', 'y1', source=src_vline,
-                color='red', line_dash='dashed', line_width=1.5)
+                color=T['marker'], line_dash='dashed', line_width=2)
 
 # lattice diagram
-LATT_COLS = {'UN': '#2176AE', 'DR': '#CCCCCC', 'CH': '#E87D2B'}
 p_latt = figure(title='Lattice',
-                x_axis_label='z (m)',
+                x_axis_label=UNITS.z_label,
                 x_range=p_power.x_range,   # share x axis with power plot
                 width=PW, height=90,
                 tools='pan,reset',
@@ -209,91 +488,235 @@ p_latt.ygrid.visible = False
 p_latt.xgrid.visible = False
 
 if latt_elements:
-    un_x, un_y, un_w, un_h     = [], [], [], []
-    dr_x, dr_y, dr_w, dr_h     = [], [], [], []
-    ch_x, ch_y, ch_w, ch_h     = [], [], [], []
-    qu_x0, qu_y0, qu_x1, qu_y1 = [], [], [], []
+    # CDS-backed so the element positions can be rescaled when the unit
+    # system changes; plain lists would be baked in at construction.
+    src_dr = ColumnDataSource(dict(x=[], y=[], w=[], h=[]))
+    src_un = ColumnDataSource(dict(x=[], y=[], w=[], h=[]))
+    src_ch = ColumnDataSource(dict(x=[], y=[], w=[], h=[]))
+    src_qu = ColumnDataSource(dict(x0=[], y0=[], x1=[], y1=[]))
 
-    for typ, zs, L in latt_elements:
-        if typ == 'UN':
-            un_x.append(zs + L/2); un_y.append(0.5)
-            un_w.append(L);        un_h.append(0.9)
-        elif typ == 'DR' and L > 0:
-            dr_x.append(zs + L/2); dr_y.append(0.5)
-            dr_w.append(L);        dr_h.append(0.5)
-        elif typ == 'CH' and L > 0:
-            ch_x.append(zs + L/2); ch_y.append(0.5)
-            ch_w.append(L);        ch_h.append(0.7)
-        elif typ == 'QU':
-            qu_x0.append(zs); qu_y0.append(0.05)
-            qu_x1.append(zs); qu_y1.append(0.95)
+    def _relayout_lattice():
+        """Rebuild the lattice glyph positions for the current units."""
+        zmul = UNITS.z_mul
+        span = (latt_z_total * zmul) if latt_z_total > 0 else 1.0
+        # A 2px gap in the surface colour separates touching elements;
+        # convert 2px of the plot's own width into the displayed z units.
+        gap = 2.0 / PW * span
+        d = {k: dict(x=[], y=[], w=[], h=[]) for k in ('DR', 'UN', 'CH')}
+        q = dict(x0=[], y0=[], x1=[], y1=[])
+        for typ, zs, L in latt_elements:
+            zs, L = zs * zmul, L * zmul
+            Lw = max(L - gap, L * 0.5)   # keep the gap from eating a short element
+            if typ == 'QU':
+                q['x0'].append(zs); q['y0'].append(0.05)
+                q['x1'].append(zs); q['y1'].append(0.95)
+            elif typ in d and (L > 0 or typ == 'UN'):
+                h = {'UN': 0.9, 'DR': 0.5, 'CH': 0.7}[typ]
+                d[typ]['x'].append(zs + L/2); d[typ]['y'].append(0.5)
+                d[typ]['w'].append(Lw);       d[typ]['h'].append(h)
+        src_dr.data, src_un.data, src_ch.data = d['DR'], d['UN'], d['CH']
+        src_qu.data = q
 
-    if dr_x:
-        p_latt.rect(dr_x, dr_y, dr_w, dr_h, color='#CCCCCC',
-                    line_color=None, alpha=0.6, legend_label='Drift')
-    if un_x:
-        p_latt.rect(un_x, un_y, un_w, un_h, color='#2176AE',
-                    line_color='white', line_width=0.5, legend_label='Undulator')
-    if ch_x:
-        p_latt.rect(ch_x, ch_y, ch_w, ch_h, color='#E87D2B',
+    _relayout_lattice()
+
+    # Drift is the absence of an element, so it stays chrome grey; the three
+    # real element types take the validated hues.
+    if src_dr.data['x']:
+        p_latt.rect('x', 'y', 'w', 'h', source=src_dr, color=T['drift'],
+                    line_color=None, alpha=0.45, legend_label='Drift')
+    if src_un.data['x']:
+        p_latt.rect('x', 'y', 'w', 'h', source=src_un, color=T['field'],
+                    line_color=None, legend_label='Undulator')
+    if src_ch.data['x']:
+        p_latt.rect('x', 'y', 'w', 'h', source=src_ch, color=T['beam'],
                     line_color=None, legend_label='Chicane')
-    if qu_x0:
-        p_latt.segment(qu_x0, qu_y0, qu_x1, qu_y1, color='#D62839',
-                       line_width=2, legend_label='Quad')
+    if src_qu.data['x0']:
+        p_latt.segment('x0', 'y0', 'x1', 'y1', source=src_qu,
+                       color=T['select'], line_width=2, legend_label='Quad')
 
-    p_latt.legend.orientation = 'horizontal'
-    p_latt.legend.label_text_font_size = '9pt'
-    p_latt.legend.spacing = 10
-    p_latt.legend.padding = 4
+    pvt.style_legend(p_latt, T)
     p_latt.add_layout(p_latt.legend[0], 'below')
 
 # z marker on lattice (shared x with power plot, so same vline source works)
-src_lmark = ColumnDataSource(dict(x0=[z_vals[0]], y0=[0.0],
-                                  x1=[z_vals[0]], y1=[1.0]))
+src_lmark = ColumnDataSource(dict(x0=[z_vals[0]*UNITS.z_mul], y0=[0.0],
+                                  x1=[z_vals[0]*UNITS.z_mul], y1=[1.0]))
 p_latt.segment('x0', 'y0', 'x1', 'y1', source=src_lmark,
-               color='red', line_dash='dashed', line_width=1.5)
+               color=T['marker'], line_dash='dashed', line_width=2)
 
 # ── status + slider ───────────────────────────────────────────────────────────
 def _status_html(idx):
-    return (f'<span style="font-size:13px"><b>Step {idx+1}/{n_files}</b> &nbsp;|&nbsp; '
-            f'file step {step_num(aperp_files[idx])} &nbsp;|&nbsp; '
-            f'z = {z_vals[idx]:.4f} m</span>')
+    return pvt.header_html(
+        T, f'{basename} · 3D field', z_vals[idx] * UNITS.z_mul, idx + 1, n_files,
+        unit=('' if UNITS.scaled else 'm'),
+        extra=f' <span style="color:{T["muted"]};">· file step '
+              f'{step_num(aperp_files[idx])}</span>')
 
-status = Div(text=_status_html(0), width=PW)
+status = Div(text=_status_html(0), width=PW,
+             margin=(14, 10, 4, SLIDER_INSET))
 
-slider = Slider(start=0, end=n_files - 1, value=0, step=1,
-                title=f'z = {z_vals[0]:.3f} m', width=PW)
+# Inset from the left so the handle at step 0 is clear of the window edge —
+# dragging there otherwise grabs the browser's resize border.
+# Bokeh rejects start == end, which is what a single-dump run would give.
+slider = Slider(start=0, end=max(n_files - 1, 1), value=0, step=1,
+                disabled=n_files < 2,
+                # No title: the header above already shows z as its hero
+                # figure and the frame counter beside it. Bokeh renders
+                # "<title>: <value>", so a title here gives either a
+                # duplicated z or, with show_value off, a dangling colon.
+                title=None, show_value=False,
+                width=PW - SLIDER_INSET - 40,
+                margin=(5, 40, 15, SLIDER_INSET))
+
+
+# Cache the loaded step so changing only the slice mode does not re-read a
+# 280 MB aperp file from disk.
+_cur = {'idx': None, 'aperp': None, 'attrs': None}
+
+
+def _load_step(idx):
+    if _cur['idx'] != idx:
+        a, at = load_aperp(aperp_files[idx])
+        _cur.update(idx=idx, aperp=a, attrs=at)
+    return _cur['aperp'], _cur['attrs']
+
+
+def refresh_xy():
+    """Redraw the x-y panels for the current step and slice mode."""
+    aperp, attrs = _load_step(int(slider.value))
+    iscale = intens_scale(attrs)
+    x0, x1, y0, y1 = xy_extent(attrs, UNITS)
+
+    iz2 = _xy_index(aperp)
+    fi, ii = field_and_intens(aperp, UNITS.intensity_factor(iscale), iz2)
+
+    src_field.data  = dict(image=[fi],  x=[x0], y=[y0], dw=[x1-x0], dh=[y1-y0])
+    src_intens.data = dict(image=[ii], x=[x0], y=[y0], dw=[x1-x0], dh=[y1-y0])
+    mapper_f.low, mapper_f.high = clim(fi)
+    mapper_i.low, mapper_i.high = clim(ii)
+
+    p_field.title.text  = 'Field magnitude' + _xy_suffix(iz2)
+    p_intens.title.text = 'Intensity' + _xy_suffix(iz2)
+    slice_span.visible  = iz2 is not None
+    if iz2 is not None:
+        slice_span.location = float(z2_ax[iz2])
+        # keep the manual slider in step when Peak mode moves the cursor
+        if xy_mode == MODE_PEAK and xy_slice_sl.value != iz2:
+            xy_slice_sl.value = iz2
+    xy_note.text = _xy_note_html(iz2)
+
+
+def apply_units():
+    """Re-label and re-scale every panel for the current UNITS."""
+    global pow_W, pow_J, ylo, yhi, _elo, _ehi, z2_ax
+
+    z2_ax = UNITS.z2_axis(NZ2, attrs0)
+    pow_W = POW_W[UNITS.mode]
+    pow_J = POW_J[UNITS.mode]
+
+    # z axis
+    zs = pow_z * UNITS.z_mul
+    if len(pow_z):
+        src_pow.data = dict(x=zs.tolist(), y=pow_W.tolist())
+        src_en.data  = dict(x=zs.tolist(), y=pow_J.tolist())
+    _z = np.concatenate([a for a in (z_vals * UNITS.z_mul, zs) if len(a)])
+    pad = max((float(_z.max()) - float(_z.min())) * 0.02, 1e-9)
+    _zrange.start, _zrange.end = float(_z.min()) - pad, float(_z.max()) + pad
+
+    if len(pow_W) and np.any(np.isfinite(pow_W)):
+        ylo, yhi = float(np.nanmin(pow_W)), float(np.nanmax(pow_W))
+    if len(pow_J) and np.any(np.isfinite(pow_J)):
+        _elo, _ehi = float(np.nanmin(pow_J)), float(np.nanmax(pow_J))
+
+    p_power.title.text = UNITS.power_title(pow_attrs)
+    p_power.xaxis.axis_label = UNITS.z_label
+    p_power.yaxis.axis_label = UNITS.power_label
+    p_energy.title.text = UNITS.energy_title(pow_attrs)
+    p_energy.xaxis.axis_label = UNITS.z_label
+    p_energy.yaxis.axis_label = UNITS.energy_label
+    p_tprof.xaxis.axis_label = UNITS.z2_label
+    p_tprof.yaxis.axis_label = UNITS.power_label
+    for f in (p_field, p_intens):
+        f.xaxis.axis_label = UNITS.x_label
+        f.yaxis.axis_label = UNITS.y_label
+    cbar_i.title = UNITS.intens_label
+    if latt_elements:
+        p_latt.xaxis.axis_label = UNITS.z_label
+        _relayout_lattice()   # defined only when latt_elements is non-empty
+
+    update(None, None, None)
+
+
+def _on_units(attr, old, new):
+    global UNITS
+    UNITS = pvd.Units(attrs0, pvd.SCALED if int(new) == 0 else pvd.SI)
+    apply_units()
+
+
+units_btn = RadioButtonGroup(labels=['Scaled', 'SI'], active=pvd.SI, width=170)
+units_btn.on_change('active', _on_units)
+
+
+def _on_xy_mode(attr, old, new):
+    global xy_mode
+    xy_mode = int(new)
+    xy_slice_sl.disabled = xy_mode != MODE_MANUAL
+    refresh_xy()
+
+
+def _on_xy_slice(attr, old, new):
+    global xy_slice
+    xy_slice = int(new)
+    if xy_mode == MODE_MANUAL:
+        refresh_xy()
+
+
+xy_mode_btn.on_change('active', _on_xy_mode)
+xy_slice_sl.on_change('value', _on_xy_slice)
 
 
 def update(attr, old, new):
     idx = int(slider.value)
-    aperp, attrs = load_aperp(aperp_files[idx])
-    iscale = intens_scale(attrs)
-    x0, x1, y0, y1 = xy_extent_mm(attrs)
-
-    fi, ii = field_and_intens(aperp, iscale)
-
-    src_field.data  = dict(image=[fi],  x=[x0], y=[y0], dw=[x1-x0], dh=[y1-y0])
-    src_intens.data = dict(image=[ii], x=[x0], y=[y0], dw=[x1-x0], dh=[y1-y0])
-    mapper_f.low, mapper_f.high = float(fi.min()), float(fi.max())
-    mapper_i.low, mapper_i.high = float(ii.min()), float(ii.max())
+    refresh_xy()
 
     z = z_vals[idx]
-    src_vline.data = dict(x0=[z], y0=[ylo], x1=[z], y1=[yhi])
-    src_lmark.data = dict(x0=[z], y0=[0.0], x1=[z], y1=[1.0])
+    zd = z * UNITS.z_mul          # z in the displayed units
+    src_vline.data  = dict(x0=[zd], y0=[ylo],  x1=[zd], y1=[yhi])
+    src_evline.data = dict(x0=[zd], y0=[_elo], x1=[zd], y1=[_ehi])
+    src_lmark.data  = dict(x0=[zd], y0=[0.0],  x1=[zd], y1=[1.0])
 
-    slider.title = f'z = {z:.3f} m'
+    # temporal profile from the integrated dump nearest this z
+    ip = _closest_int_file(z)
+    if ip:
+        tx, ty = load_power_profile(ip, UNITS)
+        src_tprof.data = dict(x=tx.tolist(), y=ty.tolist())
+    else:
+        src_tprof.data = dict(x=[], y=[])
+
     status.text  = _status_html(idx)
 
 
 slider.on_change('value', update)
 
+# Playback. Registered after `update` so a timer tick redraws the panels
+# before the player's own slider handler runs.
+player = pvp.Player(curdoc(), slider, n_files, T)
+
 # ── layout ────────────────────────────────────────────────────────────────────
-curdoc().add_root(column(
-    status,
-    row(p_field, p_intens),
-    p_power,
-    p_latt,
-    slider,
-))
+# A deck with no lattice file (fig7a, the PhyOfPlasmas examples) would
+# otherwise get an empty titled panel with just an axis in it — the power
+# plot already carries the z cue, so drop it rather than show a blank.
+_panels = [status,
+           row(player.layout(inset=SLIDER_INSET, top=0, bottom=0),
+               units_btn),
+           slider]
+if latt_elements:
+    _panels.append(p_latt)
+_panels += [row(p_power, p_energy),
+            p_tprof,
+            row(xy_mode_btn, xy_slice_sl,
+                margin=(2, 10, 0, SLIDER_INSET)),
+            xy_note,
+            row(p_field, p_intens)]
+
+curdoc().add_root(column(*_panels))
 curdoc().title = f'Puffin Field Viewer — {basename}'

--- a/utilities/pyPlotting/viewField3D_bokeh.py
+++ b/utilities/pyPlotting/viewField3D_bokeh.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""
+Interactive Bokeh viewer for Puffin 3D field output (aperp_*.h5).
+
+Run with:
+    bokeh serve --show viewField3D_bokeh.py --args /path/to/data [basename] [lattice.latt]
+
+Controls:
+    Slider  — scrub through output steps; title shows z (m)
+"""
+
+import sys, os, glob, re
+import numpy as np
+import h5py
+
+from bokeh.plotting import figure, curdoc
+from bokeh.models import (ColumnDataSource, Slider, LinearColorMapper,
+                           ColorBar, Div, Segment)
+from bokeh.layouts import column, row
+from bokeh.palettes import Inferno256
+
+# ── physical constants ──────────────────────────────────────────────────────
+C0   = 2.99792458e8
+QE   = 1.60217653e-19
+EPS0 = 8.854187817e-12
+ME   = 9.1093826e-31
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def step_num(path):
+    m = re.search(r'_(\d+)\.h5$', path)
+    return int(m.group(1)) if m else 0
+
+def intens_scale(attrs):
+    return C0 * EPS0 * (attrs['gamma_r'] * ME * C0**2
+                        / (QE * attrs['kappa'] * attrs['Lg']))**2
+
+def xy_extent_mm(attrs):
+    dx = attrs['sLengthOfElmX'] * np.sqrt(attrs['Lg'] * attrs['Lc'])
+    dy = attrs['sLengthOfElmY'] * np.sqrt(attrs['Lg'] * attrs['Lc'])
+    nx, ny = int(attrs['nX']), int(attrs['nY'])
+    return -nx/2*dx*1e3, nx/2*dx*1e3, -ny/2*dy*1e3, ny/2*dy*1e3
+
+def load_aperp(path):
+    with h5py.File(path, 'r') as f:
+        aperp = f['aperp'][()]          # (2, nz2, ny, nx)
+        attrs = dict(f['runInfo'].attrs)
+    return aperp, attrs
+
+def field_and_intens(aperp, iscale):
+    mag = np.mean(np.sqrt(aperp[0]**2 + aperp[1]**2), axis=0)  # z2-avg |A|
+    ixy = np.mean(aperp[0]**2 + aperp[1]**2, axis=0) * iscale  # z2-avg intensity
+    return mag, ixy
+
+
+# ── parse arguments ───────────────────────────────────────────────────────────
+# bokeh serve passes everything after --args into sys.argv[1:]
+args = sys.argv[1:]
+data_dir  = args[0] if len(args) > 0 else '.'
+basename  = args[1] if len(args) > 1 else None
+latt_arg  = args[2] if len(args) > 2 else None
+
+
+# ── collect aperp files ───────────────────────────────────────────────────────
+all_h5 = glob.glob(os.path.join(data_dir, '*_aperp_*.h5'))
+if not all_h5:
+    raise RuntimeError(f'No aperp HDF5 files found in {data_dir}')
+
+if basename is None:
+    basename = re.sub(r'_aperp_\d+\.h5$', '',
+                      os.path.basename(sorted(all_h5, key=step_num)[0]))
+
+aperp_files = sorted(
+    glob.glob(os.path.join(data_dir, f'{basename}_aperp_*.h5')),
+    key=step_num)
+n_files = len(aperp_files)
+print(f'Found {n_files} aperp files  (basename="{basename}")', flush=True)
+
+
+# ── pre-scan z positions (attrs only — fast) ──────────────────────────────────
+print('Scanning z positions...', end=' ', flush=True)
+z_vals = []
+for p in aperp_files:
+    with h5py.File(p, 'r') as f:
+        z_vals.append(float(f['runInfo'].attrs['zTotal']))
+z_vals = np.array(z_vals)
+print('done', flush=True)
+
+
+# ── power curve from integrated files ─────────────────────────────────────────
+int_files = sorted(
+    glob.glob(os.path.join(data_dir, f'{basename}_integrated_*.h5')),
+    key=step_num)
+pow_z, pow_W = np.array([]), np.array([])
+if int_files:
+    print(f'Loading power curve ({len(int_files)} files)...', end=' ', flush=True)
+    pz, pw = [], []
+    for p in int_files:
+        with h5py.File(p, 'r') as f:
+            pz.append(float(f['runInfo'].attrs['zTotal']))
+            pw.append(float(np.mean(f['powerSI'][()])))
+    pow_z = np.array(pz)
+    pow_W = np.array(pw)
+    # guard against zeros on log axis
+    pow_W = np.where(pow_W > 0, pow_W, np.nan)
+    print('done', flush=True)
+
+
+# ── lattice ───────────────────────────────────────────────────────────────────
+def parse_lattice(latt_path, lw):
+    elements, z = [], 0.0
+    with open(latt_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith('!'): continue
+            tag  = line[:2].upper()
+            nums = list(map(float, re.findall(
+                r'[-+]?\d*\.?\d+(?:[eE][-+]?\d+)?', line[2:])))
+            if tag == 'UN' and nums:
+                L = int(nums[0]) * lw;  elements.append(('UN', z, L));  z += L
+            elif tag == 'DR' and nums:
+                L = nums[0] * lw;       elements.append(('DR', z, L));  z += L
+            elif tag == 'CH' and nums:
+                L = nums[0] * lw
+                if L > 0: elements.append(('CH', z, L));  z += L
+            elif tag == 'QU':
+                elements.append(('QU', z, 0.0))
+    return elements, z
+
+# find lattice file
+if latt_arg:
+    latt_file = latt_arg
+else:
+    candidates = (glob.glob(os.path.join(data_dir, '*.latt')) +
+                  glob.glob(os.path.join(os.path.dirname(os.path.abspath(data_dir)), '*.latt')))
+    latt_file = candidates[0] if candidates else None
+
+with h5py.File(aperp_files[0], 'r') as f:
+    lambda_w = float(f['runInfo'].attrs.get('lambda_w', 0.0275))
+
+latt_elements, latt_z_total = [], 0.0
+if latt_file and os.path.exists(latt_file):
+    latt_elements, latt_z_total = parse_lattice(latt_file, lambda_w)
+    print(f'Lattice: {len(latt_elements)} elements, total z = {latt_z_total:.3f} m', flush=True)
+
+
+# ── initial field data ────────────────────────────────────────────────────────
+aperp0, attrs0 = load_aperp(aperp_files[0])
+iscale0 = intens_scale(attrs0)
+xmin, xmax, ymin, ymax = xy_extent_mm(attrs0)
+fi0, ii0 = field_and_intens(aperp0, iscale0)
+
+
+# ── figures ───────────────────────────────────────────────────────────────────
+TOOLS = 'pan,wheel_zoom,box_zoom,reset,save'
+IW, IH = 430, 390   # image panel size
+
+mapper_f = LinearColorMapper(palette=Inferno256, low=float(fi0.min()), high=float(fi0.max()))
+mapper_i = LinearColorMapper(palette=Inferno256, low=float(ii0.min()), high=float(ii0.max()))
+
+src_field  = ColumnDataSource(dict(image=[fi0],  x=[xmin], y=[ymin],
+                                   dw=[xmax-xmin], dh=[ymax-ymin]))
+src_intens = ColumnDataSource(dict(image=[ii0], x=[xmin], y=[ymin],
+                                   dw=[xmax-xmin], dh=[ymax-ymin]))
+
+p_field = figure(title='Field magnitude  (z₂-avg, scaled)',
+                 x_axis_label='x (mm)', y_axis_label='y (mm)',
+                 width=IW, height=IH, tools=TOOLS)
+p_field.image('image', source=src_field, x='x', y='y', dw='dw', dh='dh',
+              color_mapper=mapper_f)
+p_field.add_layout(ColorBar(color_mapper=mapper_f, label_standoff=8,
+                             width=12, title='|A⊥|'), 'right')
+
+p_intens = figure(title='Intensity  (z₂-avg)',
+                  x_axis_label='x (mm)', y_axis_label='y (mm)',
+                  width=IW, height=IH, tools=TOOLS)
+p_intens.image('image', source=src_intens, x='x', y='y', dw='dw', dh='dh',
+               color_mapper=mapper_i)
+p_intens.add_layout(ColorBar(color_mapper=mapper_i, label_standoff=8,
+                              width=12, title='W/m²'), 'right')
+
+# power vs z
+PW = IW * 2 + 20
+p_power = figure(title='Power vs z', x_axis_label='z (m)', y_axis_label='Power (W)',
+                 width=PW, height=220, tools=TOOLS, y_axis_type='log')
+if len(pow_z):
+    src_pow = ColumnDataSource(dict(x=pow_z.tolist(), y=pow_W.tolist()))
+    p_power.line('x', 'y', source=src_pow, color='royalblue', line_width=1.5)
+    ylo = float(np.nanmin(pow_W)); yhi = float(np.nanmax(pow_W))
+else:
+    ylo, yhi = 1e-3, 1e10
+
+src_vline = ColumnDataSource(dict(x0=[z_vals[0]], y0=[ylo],
+                                  x1=[z_vals[0]], y1=[yhi]))
+p_power.segment('x0', 'y0', 'x1', 'y1', source=src_vline,
+                color='red', line_dash='dashed', line_width=1.5)
+
+# lattice diagram
+LATT_COLS = {'UN': '#2176AE', 'DR': '#CCCCCC', 'CH': '#E87D2B'}
+p_latt = figure(title='Lattice',
+                x_axis_label='z (m)',
+                x_range=p_power.x_range,   # share x axis with power plot
+                width=PW, height=90,
+                tools='pan,reset',
+                y_range=(-0.05, 1.05))
+p_latt.yaxis.visible = False
+p_latt.ygrid.visible = False
+p_latt.xgrid.visible = False
+
+if latt_elements:
+    un_x, un_y, un_w, un_h     = [], [], [], []
+    dr_x, dr_y, dr_w, dr_h     = [], [], [], []
+    ch_x, ch_y, ch_w, ch_h     = [], [], [], []
+    qu_x0, qu_y0, qu_x1, qu_y1 = [], [], [], []
+
+    for typ, zs, L in latt_elements:
+        if typ == 'UN':
+            un_x.append(zs + L/2); un_y.append(0.5)
+            un_w.append(L);        un_h.append(0.9)
+        elif typ == 'DR' and L > 0:
+            dr_x.append(zs + L/2); dr_y.append(0.5)
+            dr_w.append(L);        dr_h.append(0.5)
+        elif typ == 'CH' and L > 0:
+            ch_x.append(zs + L/2); ch_y.append(0.5)
+            ch_w.append(L);        ch_h.append(0.7)
+        elif typ == 'QU':
+            qu_x0.append(zs); qu_y0.append(0.05)
+            qu_x1.append(zs); qu_y1.append(0.95)
+
+    if dr_x:
+        p_latt.rect(dr_x, dr_y, dr_w, dr_h, color='#CCCCCC',
+                    line_color=None, alpha=0.6, legend_label='Drift')
+    if un_x:
+        p_latt.rect(un_x, un_y, un_w, un_h, color='#2176AE',
+                    line_color='white', line_width=0.5, legend_label='Undulator')
+    if ch_x:
+        p_latt.rect(ch_x, ch_y, ch_w, ch_h, color='#E87D2B',
+                    line_color=None, legend_label='Chicane')
+    if qu_x0:
+        p_latt.segment(qu_x0, qu_y0, qu_x1, qu_y1, color='#D62839',
+                       line_width=2, legend_label='Quad')
+
+    p_latt.legend.orientation = 'horizontal'
+    p_latt.legend.label_text_font_size = '9pt'
+    p_latt.legend.spacing = 10
+    p_latt.legend.padding = 4
+    p_latt.add_layout(p_latt.legend[0], 'below')
+
+# z marker on lattice (shared x with power plot, so same vline source works)
+src_lmark = ColumnDataSource(dict(x0=[z_vals[0]], y0=[0.0],
+                                  x1=[z_vals[0]], y1=[1.0]))
+p_latt.segment('x0', 'y0', 'x1', 'y1', source=src_lmark,
+               color='red', line_dash='dashed', line_width=1.5)
+
+# ── status + slider ───────────────────────────────────────────────────────────
+def _status_html(idx):
+    return (f'<span style="font-size:13px"><b>Step {idx+1}/{n_files}</b> &nbsp;|&nbsp; '
+            f'file step {step_num(aperp_files[idx])} &nbsp;|&nbsp; '
+            f'z = {z_vals[idx]:.4f} m</span>')
+
+status = Div(text=_status_html(0), width=PW)
+
+slider = Slider(start=0, end=n_files - 1, value=0, step=1,
+                title=f'z = {z_vals[0]:.3f} m', width=PW)
+
+
+def update(attr, old, new):
+    idx = int(slider.value)
+    aperp, attrs = load_aperp(aperp_files[idx])
+    iscale = intens_scale(attrs)
+    x0, x1, y0, y1 = xy_extent_mm(attrs)
+
+    fi, ii = field_and_intens(aperp, iscale)
+
+    src_field.data  = dict(image=[fi],  x=[x0], y=[y0], dw=[x1-x0], dh=[y1-y0])
+    src_intens.data = dict(image=[ii], x=[x0], y=[y0], dw=[x1-x0], dh=[y1-y0])
+    mapper_f.low, mapper_f.high = float(fi.min()), float(fi.max())
+    mapper_i.low, mapper_i.high = float(ii.min()), float(ii.max())
+
+    z = z_vals[idx]
+    src_vline.data = dict(x0=[z], y0=[ylo], x1=[z], y1=[yhi])
+    src_lmark.data = dict(x0=[z], y0=[0.0], x1=[z], y1=[1.0])
+
+    slider.title = f'z = {z:.3f} m'
+    status.text  = _status_html(idx)
+
+
+slider.on_change('value', update)
+
+# ── layout ────────────────────────────────────────────────────────────────────
+curdoc().add_root(column(
+    status,
+    row(p_field, p_intens),
+    p_power,
+    p_latt,
+    slider,
+))
+curdoc().title = f'Puffin Field Viewer — {basename}'


### PR DESCRIPTION
Adds interactive field viewers for Puffin HDF5 output, plus three shared
modules that keep them consistent. Python only — nothing under `puffin/` is
touched, so there is no effect on the solver or on any test.

## What it adds

`utilities/pyPlotting/`:

| file | |
|---|---|
| `viewField1D_bokeh.py` | 1D dashboard: temporal profile, spectra, beam current, phase space, power/energy vs z, lattice |
| `viewField3D_bokeh.py` | 3D dashboard: transverse field/intensity, temporal profile, power/energy vs z, lattice |
| `viewField3D.py` | matplotlib equivalent of the 3D viewer (native window, no server) |
| `puffin_viz_theme.py` | look — palette, fonts, chrome |
| `puffin_viz_player.py` | behaviour — playback transport |
| `puffin_viz_data.py` | correctness — how HDF5 becomes a plotted number |

The three modules are split by what goes wrong when each is wrong, which is
also why the reductions live on their own rather than inside a theme module.

Run with:

```
bokeh serve --show utilities/pyPlotting/viewField3D_bokeh.py \
  --args /path/to/data [basename] [lattice.latt]
```

Requires `bokeh`, `h5py`, `numpy` (and `matplotlib` for `viewField3D.py`).

## Features

- **Playback** — play/pause, frame step, speed ladder (0.5–16 fps). The
  ceiling is set by pushing a ~1e5-point phase-space scatter over the
  websocket, not by the server-side step (~0.06 s/frame on a 280 MB dump).
- **Scaled / SI toggle.** Where Puffin already writes both forms
  (`power`/`powerSI`, `beamCurrent`/`beamCurrentSI`, `Intensity`/`IntensitySI`)
  the viewers **select the dataset** rather than converting, so they never
  restate Puffin's own scaling constants. Only the geometric axes
  (z̄ = z/Lg, x̄ = x/√(Lg·Lc)) are computed. Both systems are built at load,
  so toggling never re-reads the integrated set.
- **z₂ slice control** on the 3D transverse panels: peak-power slice
  (tracked per step), manual, or z₂-average, with a cursor on the temporal
  profile showing which node is displayed.
- Dark theme via `PUFFIN_VIZ_THEME=dark`.

## Reductions are mesh-type aware

This is the part most worth reviewing. Everything keys off
`runInfo.attrs['fieldMesh']` (`iTemporal = 0` / `iPeriodic = 1`, per
`puffin/lib/deriv_globals.f90`). On a **temporal** mesh the pulse fills only
part of the z₂ window, so averaging over that window is not a property of the
radiation — halve `sFModelLengthZ2` and the answer doubles.

Measured on `inputs/simple/3D/PhyOfPlasmasV19pp093119/fig7a` (fill factor 24%):

- **Power vs z** — `mean(powerSI)` is a genuine cycle average on a periodic
  mesh, but on a pulse it understates by the fill factor. Now peak on a
  temporal mesh, mean on a periodic one, **labelled with which was used**.
  The two differ by 4.7× here.
- **Transverse panels** — averaging over all z₂ nodes understates peak
  intensity by **11.9×** (70% of nodes sit below 1% of peak) and smears
  together slices whose spot size varies **50%** along the pulse.

**Judgement call for reviewers:** peak power is used for a pulse because it is
window-independent and is the standard quantity; pulse energy (also plotted)
would be the other defensible choice. Easy to change — one function in
`puffin_viz_data.py`.

## Added plots

- **Pulse energy vs z**, separate from peak power (different quantities, so
  separate panels rather than twin axes). Sanity-checked against the beam
  energy budget: fig7a radiates **1.926 mJ** against a ρ·E_beam ceiling of
  **1.985 mJ** — 97%, as expected at saturation.
- **Temporal profile** (power vs ct−z), which is what reveals fig7a's double
  CSE spike from the rounded current edges.

In 1D the intensity and power temporal panels are merged, intensity on the
left axis and power on the right. This is a twin axis, so to be explicit
about why it is safe: in 1D the two are *exactly* proportional (ratio
constant to 0.000000%, correlation 1.00000000 — π in SI, 1.98e7 scaled), so
the second axis is a unit relabel of a single curve, not two series on
independent scales. The factor is derived from the data rather than from the
scaling algebra, and both ranges are `Range1d` — Bokeh's default
`DataRange1d` re-derives its limits client-side, which would let the two axes
silently stop corresponding.

## Bugs fixed along the way

Found by rendering output and inspecting it:

- An all-zero first dump mapped to mid-Inferno, so an **empty mesh rendered as
  a saturated one**. Colour limits now anchor to [0, 1].
- `viewField3D.py` did not mask zero power, poisoning the log axis.
- Log axis used where data spans under a decade, crowding every tick into the
  top of the frame; now chosen from the range.
- Power curve squashed into a sliver when a run covers only the head of a long
  lattice; the z range now spans the simulated z.
- Colorbar exponents clipped (`6.000` shown for `6.000e-4`).
- Toolbar overlaid the colorbar labels.
- A missing lattice file drew an empty panel **silently**; now warns and falls
  back to auto-detection, and the panel is omitted when a deck has no lattice.
- `Slider(start == end)` raised `E-1021` on a single-dump run.
- `viewField3D.py` hardcoded the MacOSX backend and so could not run headless;
  it now honours `MPLBACKEND`.

## Testing

Exercised on `inputs/simple/1D/osc-linear-taper`,
`inputs/simple/1D/2colour/wchicanes`, `inputs/simple/3D/CLARA/single-slice`
and `inputs/simple/3D/PhyOfPlasmasV19pp093119/fig7a`, covering both periodic
and temporal meshes and both mesh branches of every reduction.

Every control driven across every step in both unit systems (play/pause, frame
step, speed, slice modes, units), plus the single-dump edge case. `ctest` still
passes 4/4 on this branch, though that only confirms nothing was disturbed —
the changes are outside the build.

Rebased onto `dev` at cadb297.
