### PR TITLE
Add a serial build mode (-DENABLE_PARALLEL=OFF)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,13 +8,27 @@ on:
 
 jobs:
   build:
+    name: build (${{ matrix.os }}, ${{ matrix.mode }})
     runs-on: ${{ matrix.os }}
     strategy:
+      # Both modes are built from the same tree but through different backend
+      # sources, so a failure in one says nothing about the other. Let each
+      # finish and report rather than cancelling its sibling.
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
+        # parallel: the usual MPI build.
+        # serial:   -DENABLE_PARALLEL=OFF, which compiles
+        #           puffin/lib/backends/serial in place of backends/mpi and
+        #           runs without a launcher. See doc/SERIAL_BUILD.md.
+        mode: [parallel, serial]
         include:
           - os: ubuntu-latest
             compiler: gcc-11
+          - mode: parallel
+            enable_parallel: 'TRUE'
+          - mode: serial
+            enable_parallel: 'FALSE'
 
     steps:
     - uses: actions/checkout@v4
@@ -49,7 +63,7 @@ jobs:
       run: |
         cmake .. \
           -DCMAKE_BUILD_TYPE=Release \
-          -DENABLE_PARALLEL:BOOL=TRUE \
+          -DENABLE_PARALLEL:BOOL=${{ matrix.enable_parallel }} \
           -DENABLE_TESTING:BOOL=TRUE \
           -DCMAKE_PREFIX_PATH='${{ github.workspace }}/pfunit-install' \
           -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install
@@ -59,6 +73,22 @@ jobs:
       working-directory: build
       run: make -j$(nproc)
     
+    - name: Check the serial build links no MPI FFTW
+      if: matrix.mode == 'serial'
+      shell: bash -l {0}
+      working-directory: build
+      # backends/serial supplies the fftw_mpi_* entry points itself, so a serial
+      # build must not link libfftw3_mpi. Nothing else would notice if it crept
+      # back in: the build would still succeed and the tests would still pass.
+      # libmpi is not checked, because it still arrives transitively whenever
+      # the HDF5 in the environment is a parallel one - as it is here.
+      run: |
+        ldd puffin/puffin
+        if ldd puffin/puffin | grep -q libfftw3_mpi; then
+          echo "::error::serial build linked libfftw3_mpi"
+          exit 1
+        fi
+
     - name: Run tests
       shell: bash -l {0}
       working-directory: build

--- a/BUILD.md
+++ b/BUILD.md
@@ -4,7 +4,7 @@ The source code is hosted [here](https://github.com/UKFELs/Puffin).
 
 ## Building from source
 
-Puffin is written in modern fortran, uses MPI for parallelism, and the post-processing scripts are in Python, using pytables and numpy. Puffin can be built using CMake. It requires the parallel (MPI) versions of the FFTW and HDF5 libraries. 
+Puffin is written in modern fortran, uses MPI for parallelism, and the post-processing scripts are in Python, using pytables and numpy. Puffin can be built using CMake. It requires the parallel (MPI) versions of the FFTW and HDF5 libraries — or, with `-DENABLE_PARALLEL=OFF`, the serial versions and no MPI at all; see [Serial builds](#serial-builds-no-mpi) below. 
 
 The below guide is for use on linux and other *nix environments. It has been built on numerous HPC clusters and large servers. On Mac OS, Homebrew can be used to install MPI, a Fortran compiler, hdf5 and fftw. In the past Puffin has been built on Windows by way of both Cygwin and WSL.
 
@@ -36,6 +36,23 @@ cmake --build ../build
 cmake --build ../build --target test
 cmake --install ../build --prefix ../install
 ```
+
+### Serial builds (no MPI)
+
+Puffin can also be built without MPI at all:
+
+```sh
+cmake -B ../build-serial -DENABLE_PARALLEL=OFF .
+cmake --build ../build-serial
+../build-serial/puffin/puffin my_deck.in     # run it directly, no mpirun
+```
+
+This needs only serial FFTW3 and HDF5, and produces an executable that is
+numerically identical to `mpirun -n 1` of the parallel build. It is meant for
+debugging, profiling and machines without MPI, not for production runs — a
+serial build puts all the work and all the memory on one core. See
+[doc/SERIAL_BUILD.md](doc/SERIAL_BUILD.md) for what it guarantees and how it is
+put together.
 
 #### Optional test tiers
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,21 @@ HDF5 dumps), and the big tests use an 85x85x5780 field mesh (~9–12GB RAM and
 ~9 min at 6 ranks). Both default to OFF — leave them that way, and only
 configure with them ON when the user explicitly asks for them.
 
+### Serial (non-MPI) builds
+
+`-DENABLE_PARALLEL=OFF` builds an executable that runs directly, with no
+`mpirun` and no MPI, FFTW3-MPI or parallel-HDF5 dependency. It is numerically
+identical to `mpirun -n 1` of the parallel build. The switch works by compiling
+one of `puffin/lib/backends/mpi/` or `puffin/lib/backends/serial/`, which define
+the same module names (`mpi`, `puffin_fftw3`, `puffin_h5_par`) with one-rank
+semantics — no call site in the physics, setup or IO code differs between the
+two modes, and there are no preprocessor conditionals. When adding a new MPI
+call, add its one-rank meaning to `backends/serial/mpi_serial.f90` too, or the
+serial build stops compiling. See `doc/SERIAL_BUILD.md`.
+
+A serial build runs `puffin_basic_tests` and `puffin_e2e_tests_serial`; the
+`@mpitest` suites are built only for a parallel configure.
+
 ### Sandboxed test runs
 
 The MPI-based e2e test targets can spuriously segfault or report "insufficient

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,12 @@ set (Puffin_VERSION_PATCH 0a)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules")
 
+# ENABLE_PARALLEL=ON  builds against a real MPI, FFTW3-MPI and parallel HDF5.
+# ENABLE_PARALLEL=OFF builds a serial executable that needs none of them: the
+# sources in puffin/lib/backends/serial stand in for the MPI module, the
+# fftw_mpi_* planner and the parallel-HDF5 property calls, all with one-rank
+# semantics. No call site elsewhere in Puffin changes between the two modes.
+# See doc/SERIAL_BUILD.md.
 option(ENABLE_PARALLEL "whether to build parallel PUFFIN" ON)
 option(USE_MKL "Use Intel MKL" OFF)
 option(ENABLE_TESTING "Enable testing" OFF)
@@ -31,6 +37,10 @@ option(ENABLE_LINT "Enable extra compiler warnings (-Wall -Wextra)" OFF)
 if(ENABLE_PARALLEL)
   find_package(MPI REQUIRED)
   set(USE_MPI 1 CACHE BOOL "setting USE_MPI to 1" FORCE)
+  message(STATUS "Building parallel Puffin (MPI enabled)")
+else()
+  set(USE_MPI 0 CACHE BOOL "setting USE_MPI to 0" FORCE)
+  message(STATUS "Building serial Puffin (MPI disabled) - run the executable directly, not under mpirun")
 endif()
 
 if (USE_MKL)
@@ -40,11 +50,27 @@ if (USE_MKL)
     set(MKL_INCLUDE_DIRS "$ENV{MKLROOT}/include")
   endif()
   message(STATUS "Using MKL. MKL_LIBRARY_DIRS: ${MKL_LIBRARY_DIRS}")
+elseif (ENABLE_PARALLEL)
+  find_package(FFTW3 REQUIRED COMPONENTS MPI)
 else()
+  # Serial build: plain FFTW3 only. backends/serial/puffin_fftw3.f90 supplies
+  # the fftw_mpi_* entry points on top of it, so libfftw3_mpi is not linked.
   find_package(FFTW3 REQUIRED)
 endif()
 
 find_package(HDF5 COMPONENTS Fortran HL REQUIRED)
+
+# A serial build never calls the MPI-IO driver, but if the HDF5 that was found
+# is itself a parallel build then linking it still drags libmpi in. That is
+# harmless - the executable is still launched directly, not under mpirun - but
+# it does mean the binary is not MPI-free. Point at a serial HDF5 with
+# HDF5_ROOT if that matters.
+if (NOT ENABLE_PARALLEL AND HDF5_IS_PARALLEL)
+  message(STATUS
+    "Serial build linked against a parallel HDF5, so libmpi comes in transitively. "
+    "Set HDF5_ROOT to a serial HDF5 for a build with no MPI dependency at all.")
+endif()
+
 find_package(OpenMP REQUIRED)
 find_package(Doxygen)
 

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -20,13 +20,29 @@ find_package(Python3 COMPONENTS Interpreter REQUIRED)
 set(PUFFIN_BENCHMARK_REPS 3 CACHE STRING
     "Repetitions per benchmark case (the minimum is reported)")
 
-set(_bench_cases 1d_serial 1d_mpi 3d_single 3d_lattice)
+# A serial build (-DENABLE_PARALLEL=OFF) has no launcher and cannot run the
+# multi-rank cases, so only the single-rank one is registered. `--serial`
+# tells the runner to invoke the executable directly. Timing 1d_serial in both
+# modes is the useful comparison: it is the same physics either way, so the
+# difference is what the MPI layer costs on one rank.
+if (ENABLE_PARALLEL)
+  set(_bench_cases 1d_serial 1d_mpi 3d_single 3d_lattice)
+  set(_bench_launcher_args "")
+  set(_bench_all_case_args "")
+else()
+  set(_bench_cases 1d_serial)
+  set(_bench_launcher_args --serial)
+  # The `benchmarks` target below defaults to every case, which would fail on
+  # the multi-rank ones here, so name the runnable subset explicitly.
+  set(_bench_all_case_args --case 1d_serial)
+endif()
 
 foreach(case IN LISTS _bench_cases)
   add_test(
     NAME benchmark_${case}
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/run_benchmarks.py
             --puffin $<TARGET_FILE:puffin>
+            ${_bench_launcher_args}
             --case ${case}
             --reps ${PUFFIN_BENCHMARK_REPS}
             --label "${GIT_REVISION}"
@@ -44,6 +60,8 @@ endforeach()
 add_custom_target(benchmarks
   COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/run_benchmarks.py
           --puffin $<TARGET_FILE:puffin>
+          ${_bench_launcher_args}
+          ${_bench_all_case_args}
           --reps ${PUFFIN_BENCHMARK_REPS}
           --label "${GIT_REVISION}"
           --output ${CMAKE_CURRENT_BINARY_DIR}/benchmarks.json

--- a/benchmark/run_benchmarks.py
+++ b/benchmark/run_benchmarks.py
@@ -79,8 +79,16 @@ def stage_inputs(workdir: Path) -> None:
 
 
 def run_once(puffin: Path, workdir: Path, deck: str, ranks: int, mpirun: str):
-    """Run one repetition; return (wall_s, undulator_s)."""
-    cmd = [mpirun, "-n", str(ranks), str(puffin), deck]
+    """Run one repetition; return (wall_s, undulator_s).
+
+    ``mpirun`` empty means the executable is a serial build (ENABLE_PARALLEL=OFF)
+    and is launched directly - there is no launcher to go through, and the
+    binary is not linked against MPI at all.
+    """
+    if mpirun:
+        cmd = [mpirun, "-n", str(ranks), str(puffin), deck]
+    else:
+        cmd = [str(puffin), deck]
     env = dict(os.environ)
     # Puffin is built with OpenMP.  Left unset, the OpenMP runtime spawns one
     # thread per core *per MPI rank*, which oversubscribes the machine and makes
@@ -124,6 +132,10 @@ def main() -> int:
     ap.add_argument("--puffin", default=str(SRC_ROOT / "build" / "puffin" / "puffin"),
                     help="path to the puffin executable to benchmark")
     ap.add_argument("--mpirun", default="mpirun", help="MPI launcher to use")
+    ap.add_argument("--serial", action="store_true",
+                    help="the executable is a serial build (ENABLE_PARALLEL=OFF): "
+                         "run it directly rather than through a launcher, and "
+                         "refuse the multi-rank cases")
     ap.add_argument("--reps", type=int, default=3,
                     help="repetitions per case (the minimum is reported)")
     ap.add_argument("--case", action="append", dest="cases", metavar="NAME",
@@ -133,6 +145,10 @@ def main() -> int:
     ap.add_argument("--workdir", help="scratch dir to run in (default: a temp dir)")
     ap.add_argument("--list", action="store_true", help="list cases and exit")
     args = ap.parse_args()
+
+    # An empty launcher is the signal to run_once that there is nothing to
+    # launch through.
+    launcher = "" if args.serial else args.mpirun
 
     if args.list:
         for name, c in CASES.items():
@@ -147,6 +163,11 @@ def main() -> int:
     for name in selected:
         if name not in CASES:
             ap.error(f"unknown case {name!r}; use --list to see the available cases")
+        if not launcher and CASES[name]["ranks"] > 1:
+            ap.error(f"case {name!r} wants {CASES[name]['ranks']} ranks, but no MPI "
+                     f"launcher was given. A serial build can only run the "
+                     f"single-rank cases: "
+                     f"{', '.join(n for n, c in CASES.items() if c['ranks'] == 1)}.")
 
     tmp = None
     if args.workdir:
@@ -166,7 +187,7 @@ def main() -> int:
             print(f"[{name}] {case['desc']}", flush=True)
             for i in range(args.reps):
                 wall, und = run_once(puffin, workdir, case["deck"], case["ranks"],
-                                     args.mpirun)
+                                     launcher)
                 walls.append(wall)
                 unds.append(und)
                 print(f"  rep {i + 1}/{args.reps}: wall {wall:7.3f} s   "

--- a/cmake/Modules/FindFFTW3.cmake
+++ b/cmake/Modules/FindFFTW3.cmake
@@ -13,6 +13,15 @@
 # ``FFTW3_LIBRARIES``
 #   List of libraries when using FFTW3.
 #
+# Components
+# ^^^^^^^^^^
+#
+# ``MPI``
+#   The distributed-memory transforms, libfftw3_mpi. Request it with
+#   ``find_package(FFTW3 REQUIRED COMPONENTS MPI)``; only then is the
+#   library added to ``FFTW3_LIBRARIES``. A serial Puffin build must not
+#   request it, since linking it would drag MPI back in.
+#
 # Hints
 # ^^^^^
 #
@@ -36,6 +45,12 @@ find_library(FFTW3_MPI_LIBRARY
   PATH_SUFFIXES lib
 )
 
+if(FFTW3_MPI_LIBRARY)
+  set(FFTW3_MPI_FOUND TRUE)
+else()
+  set(FFTW3_MPI_FOUND FALSE)
+endif()
+
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(FFTW3
   REQUIRED_VARS FFTW3_LIBRARY FFTW3_INCLUDE_DIR
@@ -45,7 +60,7 @@ find_package_handle_standard_args(FFTW3
 if(FFTW3_FOUND)
   set(FFTW3_INCLUDE_DIRS ${FFTW3_INCLUDE_DIR})
   set(FFTW3_LIBRARIES ${FFTW3_LIBRARY})
-  if(FFTW3_MPI_LIBRARY)
+  if(FFTW3_MPI_LIBRARY AND "MPI" IN_LIST FFTW3_FIND_COMPONENTS)
     list(APPEND FFTW3_LIBRARIES ${FFTW3_MPI_LIBRARY})
   endif()
 endif()

--- a/doc/SERIAL_BUILD.md
+++ b/doc/SERIAL_BUILD.md
@@ -136,6 +136,12 @@ if that matters. CMake says so at configure time.
 The `puffin_e2e_tests*` suites are declared `@mpitest(npes=[2])` and so are
 built only for a parallel configure, as are the opt-in slow and big tiers.
 
+CI covers both modes: `.github/workflows/build.yml` runs its `build` job over a
+`mode: [parallel, serial]` matrix, so the serial backend is built and tested on
+every push and pull request. The serial leg also asserts that the executable
+does not link `libfftw3_mpi` — nothing else would notice if it crept back in,
+since the build would still succeed and the tests would still pass.
+
 Benchmarks work too, for the single-rank case:
 
 ```sh

--- a/doc/SERIAL_BUILD.md
+++ b/doc/SERIAL_BUILD.md
@@ -1,0 +1,158 @@
+# Serial builds of Puffin
+
+Puffin is an MPI code. It can also be built without MPI:
+
+```sh
+cmake -B ../build-serial -DENABLE_PARALLEL=OFF .
+cmake --build ../build-serial
+../build-serial/puffin/puffin my_deck.in       # note: no mpirun
+```
+
+The result is an ordinary executable. It is launched directly, needs no
+launcher, and does not link `libmpi` or `libfftw3_mpi`.
+
+This is useful for debugging (`gdb ./puffin` rather than attaching to a rank),
+for profiling and single-core benchmarking, for running on a machine with no
+MPI installed, and for isolating whether a problem is in the physics or in the
+domain decomposition.
+
+It is **not** a performance feature. A serial build is a one-rank run, with all
+of the memory and all of the work on one core. Production runs still want MPI.
+
+
+## What the serial build guarantees
+
+A serial build is numerically identical to `mpirun -n 1` of the same source,
+except where FFTW's planner legitimately differs (see below). Verified on the
+committed test decks:
+
+| Deck | Serial vs `mpirun -n 1` |
+| --- | --- |
+| `test/inputs/f1main.in` (1D) | field, electrons and integrated data bit-exact |
+| `test/inputs/1D/osc_taper.in` (1D, periodic mesh, 5 modules) | field and electrons bit-exact |
+| `test/inputs/3D/clara_test.in` (3D, periodic mesh, diffraction) | electrons bit-exact; field agrees to 4e-15 relative |
+
+The 3D field is not bit-exact because FFTW's serial planner and its MPI planner
+pick different codelets for the same transform, and so sum in a different order.
+The residual is a few ULP - max absolute difference 5.3e-18 against a field
+maximum of 1.3e-3 - which is four orders of magnitude inside the 1e-10 tolerance
+the E2E tests use.
+
+Note that a one-rank run is not in general bit-identical to a two-rank run of
+the same deck, in either build mode: reductions sum in a different order, and
+for decks that generate their own beam each rank seeds its own RNG stream. That
+is a pre-existing property of Puffin, not something the serial mode introduces.
+
+
+## How it works
+
+No call site anywhere in the physics, setup or IO code changes between the two
+modes, and there are no preprocessor conditionals in them. Instead, one of two
+directories of backend modules is compiled in:
+
+```
+puffin/lib/backends/mpi/      compiled when ENABLE_PARALLEL=ON
+puffin/lib/backends/serial/   compiled when ENABLE_PARALLEL=OFF
+```
+
+Both define the same module names with the same public interfaces, so which one
+was built is invisible to everything downstream. `puffin/CMakeLists.txt` picks
+the directory; the source globs never see both, because the backends sit two
+levels below `lib/` and the globs only reach one.
+
+There are three backend modules.
+
+### `mpi` (serial only: `backends/serial/mpi_serial.f90`)
+
+Puffin's `use mpi, only: ...` statements resolve against a module literally
+called `mpi`. In a parallel build that is the MPI library's own; in a serial
+build it is this one, which exports exactly the subset of the MPI-3 Fortran API
+that Puffin uses, implemented for a communicator of size 1:
+
+- `MPI_COMM_SIZE` returns 1, `MPI_COMM_RANK` returns 0.
+- Barriers, waits, `MPI_BCAST`, init and finalize are no-ops - a broadcast from
+  the only rank to itself has nothing to move.
+- Reductions, gathers, scatters and all-to-alls copy the send buffer to the
+  receive buffer at the displacement MPI defines, or do nothing at all when the
+  caller passes `MPI_IN_PLACE` (detected by address, as real MPI does).
+- Sends and receives are supported **only to and from ourselves**, through a
+  small FIFO of buffered messages. Puffin genuinely needs this: with a periodic
+  field mesh, rank 0 and rank `size-1` are the same process when `size == 1`,
+  and the wrap-around in `para_field.f90` posts an `MPI_ISSEND` to itself and
+  then receives it.
+- Anything that can only mean something on more than one rank - a send to a
+  rank that does not exist, a receive with no matching message already posted -
+  stops the run with a diagnostic. That is deliberate. A stub that silently
+  skipped a real communication would produce plausible but wrong physics.
+
+Buffer arguments are `type(*), dimension(..)` (assumed-type, assumed-rank), so
+one implementation serves every type and rank Puffin passes, mirroring the
+`<type> buf(*)` of the real Fortran bindings. Payloads move as raw bytes, the
+size coming from the `count` and `datatype` arguments.
+
+### `puffin_fftw3`
+
+Puffin plans its 3D transforms with FFTW3-MPI. The serial backend includes
+plain `fftw3.f03` and adds the four `fftw_mpi_*` entry points the transform
+layer calls, on top of their serial counterparts. FFTW-MPI distributes a 3D
+transform over the slowest dimension, so on one rank the local size is the whole
+array, the offset is zero, and the plan is an ordinary in-place serial plan over
+the same dimensions. `transforms.f90` is unchanged.
+
+`cmake/Modules/FindFFTW3.cmake` gained an `MPI` component for this: only a
+parallel configure requests it, so a serial build never links `libfftw3_mpi`.
+
+### `puffin_h5_par`
+
+HDF5 defines `h5pset_fapl_mpio_f` and `h5pset_dxpl_mpio_f` only when it has
+itself been built against MPI, so a serial build cannot import them from the
+`hdf5` module at all. Both become no-ops here, leaving the file-access and
+transfer property lists at their defaults: on one rank the MPI-IO driver and
+the default POSIX one write byte-identical files, and a collective transfer
+degenerates to an independent one. The hyperslab selections are untouched, so
+the file layout matches the parallel build exactly.
+
+The two IO modules that used these names, `h5_in.f90` and `hdf5_puff_coll.f90`,
+now import them from `puffin_h5_par` rather than from `hdf5`. That is the only
+change to existing source outside the build files.
+
+If the HDF5 that CMake finds is itself a parallel build, linking it still pulls
+`libmpi` in transitively. The executable is still launched directly and never
+calls MPI, but the binary is not MPI-free; point `HDF5_ROOT` at a serial HDF5
+if that matters. CMake says so at configure time.
+
+
+## Testing
+
+`ctest` on a serial build runs:
+
+- `puffin_basic_tests` - the same unit tests as the parallel build.
+- `puffin_e2e_tests_serial` - `test/testSerialIntegration.pf`, which runs the
+  full 1D `f1main` deck in-process and checks it against the same golden files
+  the parallel integration test uses. Those references were captured from a
+  two-rank run, so agreeing with them to 1e-10 is the statement that matters:
+  turning MPI off does not change the physics.
+
+The `puffin_e2e_tests*` suites are declared `@mpitest(npes=[2])` and so are
+built only for a parallel configure, as are the opt-in slow and big tiers.
+
+Benchmarks work too, for the single-rank case:
+
+```sh
+cmake -B ../build-serial -DENABLE_PARALLEL=OFF -DENABLE_BENCHMARKS=ON .
+ctest --test-dir ../build-serial -L benchmark
+```
+
+`benchmark/run_benchmarks.py --mpirun ""` runs the executable directly instead
+of through a launcher. Only the `1d_serial` case is registered in serial mode;
+timing it in both modes is the interesting comparison, since it is the same
+physics either way and the difference is what the MPI layer costs on one rank.
+
+
+## Adding code that communicates
+
+If you add an MPI call that Puffin does not already make, the serial build will
+fail to compile: the stub exports only the names in use. Add the routine to
+`backends/serial/mpi_serial.f90` with its one-rank meaning, and to the `public`
+list. Keep the "abort rather than guess" rule for anything whose one-rank
+behaviour is not well defined.

--- a/puffin/CMakeLists.txt
+++ b/puffin/CMakeLists.txt
@@ -10,6 +10,22 @@ FILE(GLOB F_LIB_SOURCES lib/*.f90 lib/*/*.f90 ${PROJECT_BINARY_DIR}/puffin/lib/c
 FILE(GLOB F_EXE_SOURCES app/*.f90)
 
 #
+# Exactly one parallelism backend is compiled in. The two directories define
+# the same module names with the same public interfaces - the MPI module
+# Puffin's `use mpi` statements resolve against, the FFTW3 bindings, and the
+# parallel-HDF5 property calls - so which one is chosen is invisible to every
+# other source file. They sit two levels below lib/ so the globs above never
+# pick up both. See doc/SERIAL_BUILD.md.
+#
+if (ENABLE_PARALLEL)
+  FILE(GLOB F_BACKEND_SOURCES lib/backends/mpi/*.f90)
+else()
+  FILE(GLOB F_BACKEND_SOURCES lib/backends/serial/*.f90)
+endif()
+
+list(APPEND F_LIB_SOURCES ${F_BACKEND_SOURCES})
+
+#
 # USE_MKL to be set by user, but actually a flag not just for MKL but for other openMP options
 # Should probably break into USE_MKL and USE_OPENMP
 # Also need to figure out if we gain from ilp64 lib instead of lp64, (also would be ilp64 blacs...)

--- a/puffin/lib/backends/mpi/puffin_fftw3.f90
+++ b/puffin/lib/backends/mpi/puffin_fftw3.f90
@@ -1,0 +1,29 @@
+! Copyright 2012-2018, University of Strathclyde
+! Authors: Lawrence T. Campbell
+! License: BSD-3-Clause
+
+!> @author
+!> Lawrence Campbell,
+!> University of Strathclyde,
+!> Glasgow, UK
+!> @brief
+!> FFTW3 bindings for the parallel build.
+!>
+!> Compiled when Puffin is configured with -DENABLE_PARALLEL=ON. It exposes
+!> the stock FFTW3-MPI Fortran interface; fftw3-mpi.f03 itself includes
+!> fftw3.f03, so both the serial and the distributed entry points come in
+!> together. The serial build supplies a module of the same name and with
+!> the same public interface in backends/serial, so nothing downstream has
+!> to know which one it got.
+
+module puffin_fftw3
+
+  use, intrinsic :: iso_c_binding, only: C_CHAR, C_DOUBLE, C_DOUBLE_COMPLEX, &
+    C_FLOAT, C_FLOAT_COMPLEX, C_FUNPTR, C_INT, C_INT32_T, C_INTPTR_T, C_PTR, C_SIZE_T
+
+  implicit none (type, external)
+public
+
+  include 'fftw3-mpi.f03'
+
+end module puffin_fftw3

--- a/puffin/lib/backends/mpi/puffin_h5_par.f90
+++ b/puffin/lib/backends/mpi/puffin_h5_par.f90
@@ -1,0 +1,32 @@
+! Copyright 2012-2018, University of Strathclyde
+! Authors: Lawrence T. Campbell
+! License: BSD-3-Clause
+
+!> @author
+!> Lawrence Campbell,
+!> University of Strathclyde,
+!> Glasgow, UK
+!> @brief
+!> Parallel-HDF5 entry points for the parallel build.
+!>
+!> Compiled when Puffin is configured with -DENABLE_PARALLEL=ON. It is a
+!> thin re-export of the four parallel-I/O names Puffin uses from HDF5, so
+!> that the IO code imports them from here rather than from the HDF5 module
+!> directly. The serial build supplies a module of the same name with the
+!> same interface in backends/serial, and that is the point of the
+!> indirection: a serial HDF5 library does not define these names at all,
+!> so a bare `use hdf5, only: h5pset_fapl_mpio_f` would fail to compile
+!> against one.
+
+module puffin_h5_par
+
+  use hdf5, only: H5FD_MPIO_COLLECTIVE_F, H5FD_MPIO_INDEPENDENT_F, &
+    h5pset_dxpl_mpio_f, h5pset_fapl_mpio_f
+
+  implicit none (type, external)
+private
+
+  public :: H5FD_MPIO_COLLECTIVE_F, H5FD_MPIO_INDEPENDENT_F, &
+             h5pset_dxpl_mpio_f, h5pset_fapl_mpio_f
+
+end module puffin_h5_par

--- a/puffin/lib/backends/serial/mpi_serial.f90
+++ b/puffin/lib/backends/serial/mpi_serial.f90
@@ -1,0 +1,632 @@
+! Copyright 2012-2018, University of Strathclyde
+! Authors: Lawrence T. Campbell
+! License: BSD-3-Clause
+
+!> @author
+!> Lawrence Campbell,
+!> University of Strathclyde,
+!> Glasgow, UK
+!> @brief
+!> Serial replacement for the MPI Fortran module.
+!>
+!> This file is compiled ONLY when Puffin is configured with
+!> -DENABLE_PARALLEL=OFF. It provides a module called `mpi` which exports
+!> exactly the subset of the MPI-3 Fortran ("mpi" module) API that Puffin
+!> uses, implemented for a communicator of size 1. Every `use mpi, only: ...`
+!> in the rest of Puffin then resolves to this module instead of the real
+!> one, so no MPI library is needed to build or run, and not a single call
+!> site in the physics, setup or IO code has to change.
+!>
+!> The contract is deliberately narrow: these routines reproduce what real
+!> MPI does on a one-rank communicator, and nothing more. Anything that can
+!> only be meaningful with more than one rank (a send to a rank other than
+!> ourselves, a receive with no matching message already posted) is a
+!> programming error here and stops the code with a diagnostic rather than
+!> silently returning wrong numbers. That is intentional: a serial build
+!> that quietly skipped a genuine communication would produce plausible but
+!> wrong physics.
+!>
+!> Self-communication IS supported, because Puffin genuinely uses it. With
+!> periodic field boundaries, rank 0 and rank `size-1` are the same process
+!> when size == 1, so the periodic wrap-around in parafield posts an issend
+!> to itself and then receives it. Those messages are buffered in a small
+!> FIFO below, which is how real MPI copes with the same pattern.
+!>
+!> Buffer arguments are declared `type(*), dimension(..)` (assumed-type,
+!> assumed-rank) so that one implementation serves every type and rank that
+!> Puffin passes, mirroring the type-agnostic `<type> buf(*)` of the real
+!> Fortran bindings. Payloads are moved as raw bytes, the count being taken
+!> from the `count` and `datatype` arguments exactly as MPI defines it.
+
+module mpi
+
+  use, intrinsic :: iso_c_binding, only: c_loc, c_f_pointer, c_associated, c_int8_t
+  use, intrinsic :: iso_fortran_env, only: int64, real64, error_unit
+
+  implicit none (type, external)
+private
+
+  public :: MPI_ALLGATHER, MPI_ALLGATHERV, MPI_ALLREDUCE, MPI_ALLTOALLV, MPI_BARRIER, MPI_BCAST, &
+             MPI_CHARACTER, MPI_COMM_RANK, MPI_COMM_SIZE, MPI_COMM_WORLD, MPI_DOUBLE_PRECISION, &
+             MPI_FINALIZE, MPI_IN_PLACE, MPI_INFO_NULL, MPI_INIT, MPI_INIT_THREAD, &
+             MPI_Initialized, MPI_INTEGER, MPI_ISSEND, MPI_LOGICAL, MPI_MAX, MPI_MIN, &
+             MPI_PROC_NULL, MPI_REAL, MPI_RECV, MPI_REDUCE, MPI_REQUEST_NULL, MPI_SCATTER, &
+             MPI_SCATTERV, MPI_SEND, MPI_STATUS_SIZE, MPI_SUM, MPI_THREAD_FUNNELED, &
+             MPI_THREAD_MULTIPLE, MPI_THREAD_SERIALIZED, MPI_THREAD_SINGLE, MPI_UNDEFINED, &
+             MPI_WAIT, MPI_WAITALL, MPI_Wtime
+
+
+!     Communicator, and the handles that go with it. The values are
+!     arbitrary; nothing outside this module may interpret them.
+
+  integer, parameter :: MPI_COMM_WORLD = 1
+  integer, parameter :: MPI_INFO_NULL = 0
+  integer, parameter :: MPI_REQUEST_NULL = -1
+  integer, parameter :: MPI_PROC_NULL = -2
+  integer, parameter :: MPI_UNDEFINED = -32766
+  integer, parameter :: MPI_STATUS_SIZE = 6
+
+!     Datatype handles. Each handle is its own extent in bytes, which is
+!     all a one-rank implementation ever needs to know about a datatype.
+!     They are distinct values so that dt_size can reject an unknown one.
+
+  integer, parameter :: MPI_CHARACTER = 1
+  integer, parameter :: MPI_INTEGER = 4
+  integer, parameter :: MPI_LOGICAL = 104
+  integer, parameter :: MPI_REAL = 204
+  integer, parameter :: MPI_DOUBLE_PRECISION = 308
+
+!     Reduction operations. On one rank a reduction is the identity, so
+!     these are never inspected; they exist so call sites still compile.
+
+  integer, parameter :: MPI_SUM = 1001
+  integer, parameter :: MPI_MAX = 1002
+  integer, parameter :: MPI_MIN = 1003
+
+!     Thread support levels, in the order MPI defines them.
+
+  integer, parameter :: MPI_THREAD_SINGLE = 0
+  integer, parameter :: MPI_THREAD_FUNNELED = 1
+  integer, parameter :: MPI_THREAD_SERIALIZED = 2
+  integer, parameter :: MPI_THREAD_MULTIPLE = 3
+
+!     MPI_IN_PLACE is identified by its address, exactly as the real
+!     implementations do, so it must be a variable rather than a constant.
+
+  integer, save, target :: MPI_IN_PLACE = -1
+
+
+!     Buffered messages posted to ourselves, awaiting a matching receive.
+!     Puffin's deepest self-exchange is a handful of messages, so a plain
+!     growable FIFO is ample.
+
+  type :: pending_msg
+    integer :: tag = 0
+    integer(kind=c_int8_t), allocatable :: payload(:)
+  end type pending_msg
+
+  integer, parameter :: initial_queue_size = 8
+
+  type(pending_msg), allocatable, save :: msg_queue(:)
+  integer, save :: n_queued = 0
+
+contains
+
+
+!> Byte extent of one element of the given datatype handle.
+
+  integer function dt_size(datatype)
+
+    implicit none (type, external)
+
+    integer, intent(in) :: datatype
+
+    select case (datatype)
+    case (MPI_CHARACTER)
+      dt_size = 1
+    case (MPI_INTEGER, MPI_REAL)
+      dt_size = 4
+    case (MPI_LOGICAL)
+      dt_size = 4
+    case (MPI_DOUBLE_PRECISION)
+      dt_size = 8
+    case default
+      write (error_unit, '(a,i0)') &
+        "serial MPI stub: unknown datatype handle ", datatype
+      error stop 1
+    end select
+
+  end function dt_size
+
+
+!> Abort with a diagnostic. Used for the operations that cannot be given a
+!> meaning on a single rank; reaching one of these means the caller assumed
+!> a genuinely distributed communicator.
+
+  subroutine serial_abort(what)
+
+    implicit none (type, external)
+
+    character(len=*), intent(in) :: what
+
+    write (error_unit, '(a)') "serial MPI stub: " // trim(what)
+    write (error_unit, '(a)') &
+      "This build has MPI disabled (-DENABLE_PARALLEL=OFF) and runs on one rank."
+    error stop 1
+
+  end subroutine serial_abort
+
+
+!> Copy nbytes bytes from sendbuf (starting soff bytes in) to recvbuf
+!> (starting roff bytes in). This is the whole of a one-rank collective:
+!> every gather, scatter, reduction and all-to-all reduces to it.
+
+  subroutine copy_bytes(sendbuf, soff, recvbuf, roff, nbytes)
+
+    implicit none (type, external)
+
+    type(*), dimension(..), contiguous, target, intent(in)    :: sendbuf
+    type(*), dimension(..), contiguous, target, intent(inout) :: recvbuf
+    integer, intent(in) :: soff, roff, nbytes
+
+    integer(kind=c_int8_t), pointer :: sb(:), rb(:)
+
+    if (nbytes <= 0) return
+
+    call c_f_pointer(c_loc(sendbuf), sb, [soff + nbytes])
+    call c_f_pointer(c_loc(recvbuf), rb, [roff + nbytes])
+
+    rb(roff+1:roff+nbytes) = sb(soff+1:soff+nbytes)
+
+  end subroutine copy_bytes
+
+
+!> .true. if buf is MPI_IN_PLACE, tested by address as MPI requires.
+
+  logical function is_in_place(buf)
+
+    implicit none (type, external)
+
+    type(*), dimension(..), contiguous, target, intent(in) :: buf
+
+    is_in_place = c_associated(c_loc(buf), c_loc(MPI_IN_PLACE))
+
+  end function is_in_place
+
+
+!-----------------------------------------------------------------------
+!     Startup, shutdown and process information
+!-----------------------------------------------------------------------
+
+  subroutine MPI_INIT(ierror)
+
+    implicit none (type, external)
+
+    integer, intent(out) :: ierror
+
+    ierror = 0
+
+  end subroutine MPI_INIT
+
+
+  subroutine MPI_INIT_THREAD(required, provided, ierror)
+
+    implicit none (type, external)
+
+    integer, intent(in)  :: required
+    integer, intent(out) :: provided
+    integer, intent(out) :: ierror
+
+!     A serial run trivially satisfies any threading level asked for: there
+!     is only ever one thread making "MPI" calls.
+
+    provided = required
+    ierror = 0
+
+  end subroutine MPI_INIT_THREAD
+
+
+  subroutine MPI_Initialized(flag, ierror)
+
+    implicit none (type, external)
+
+    logical, intent(out) :: flag
+    integer, intent(out) :: ierror
+
+    flag = .true.
+    ierror = 0
+
+  end subroutine MPI_Initialized
+
+
+  subroutine MPI_FINALIZE(ierror)
+
+    implicit none (type, external)
+
+    integer, intent(out) :: ierror
+
+    if (allocated(msg_queue)) deallocate(msg_queue)
+    n_queued = 0
+    ierror = 0
+
+  end subroutine MPI_FINALIZE
+
+
+  subroutine MPI_COMM_RANK(comm, rank, ierror)
+
+    implicit none (type, external)
+
+    integer, intent(in)  :: comm
+    integer, intent(out) :: rank
+    integer, intent(out) :: ierror
+
+    rank = 0
+    ierror = 0
+
+  end subroutine MPI_COMM_RANK
+
+
+  subroutine MPI_COMM_SIZE(comm, size, ierror)
+
+    implicit none (type, external)
+
+    integer, intent(in)  :: comm
+    integer, intent(out) :: size
+    integer, intent(out) :: ierror
+
+    size = 1
+    ierror = 0
+
+  end subroutine MPI_COMM_SIZE
+
+
+!> Wall-clock seconds, matching MPI_Wtime's contract that only differences
+!> between two calls are meaningful.
+
+  real(kind=real64) function MPI_Wtime()
+
+    implicit none (type, external)
+
+    integer(kind=int64) :: ticks, rate
+
+    call system_clock(count=ticks, count_rate=rate)
+
+    if (rate > 0_int64) then
+      MPI_Wtime = real(ticks, real64) / real(rate, real64)
+    else
+      MPI_Wtime = 0.0_real64
+    end if
+
+  end function MPI_Wtime
+
+
+  subroutine MPI_BARRIER(comm, ierror)
+
+    implicit none (type, external)
+
+    integer, intent(in)  :: comm
+    integer, intent(out) :: ierror
+
+    ierror = 0
+
+  end subroutine MPI_BARRIER
+
+
+!-----------------------------------------------------------------------
+!     Collectives
+!-----------------------------------------------------------------------
+
+!> On one rank a reduction returns its own contribution unchanged, so this
+!> is a copy - or nothing at all, when the caller reduces in place.
+
+  subroutine MPI_ALLREDUCE(sendbuf, recvbuf, count, datatype, op, comm, ierror)
+
+    implicit none (type, external)
+
+    type(*), dimension(..), contiguous, target, intent(in)    :: sendbuf
+    type(*), dimension(..), contiguous, target, intent(inout) :: recvbuf
+    integer, intent(in)  :: count, datatype, op, comm
+    integer, intent(out) :: ierror
+
+    ierror = 0
+    if (is_in_place(sendbuf)) return
+
+    call copy_bytes(sendbuf, 0, recvbuf, 0, count * dt_size(datatype))
+
+  end subroutine MPI_ALLREDUCE
+
+
+  subroutine MPI_REDUCE(sendbuf, recvbuf, count, datatype, op, root, comm, ierror)
+
+    implicit none (type, external)
+
+    type(*), dimension(..), contiguous, target, intent(in)    :: sendbuf
+    type(*), dimension(..), contiguous, target, intent(inout) :: recvbuf
+    integer, intent(in)  :: count, datatype, op, root, comm
+    integer, intent(out) :: ierror
+
+    ierror = 0
+    if (is_in_place(sendbuf)) return
+
+!     The only rank is the root, so the result always lands here.
+
+    call copy_bytes(sendbuf, 0, recvbuf, 0, count * dt_size(datatype))
+
+  end subroutine MPI_REDUCE
+
+
+!> Broadcast from the only rank to itself: the buffer already holds the
+!> value, so there is nothing to move.
+
+  subroutine MPI_BCAST(buffer, count, datatype, root, comm, ierror)
+
+    implicit none (type, external)
+
+    type(*), dimension(..), contiguous, target, intent(inout) :: buffer
+    integer, intent(in)  :: count, datatype, root, comm
+    integer, intent(out) :: ierror
+
+    ierror = 0
+
+  end subroutine MPI_BCAST
+
+
+  subroutine MPI_ALLGATHER(sendbuf, sendcount, sendtype, &
+                           recvbuf, recvcount, recvtype, comm, ierror)
+
+    implicit none (type, external)
+
+    type(*), dimension(..), contiguous, target, intent(in)    :: sendbuf
+    type(*), dimension(..), contiguous, target, intent(inout) :: recvbuf
+    integer, intent(in)  :: sendcount, sendtype, recvcount, recvtype, comm
+    integer, intent(out) :: ierror
+
+    ierror = 0
+
+    call copy_bytes(sendbuf, 0, recvbuf, 0, sendcount * dt_size(sendtype))
+
+  end subroutine MPI_ALLGATHER
+
+
+  subroutine MPI_ALLGATHERV(sendbuf, sendcount, sendtype, &
+                            recvbuf, recvcounts, displs, recvtype, comm, ierror)
+
+    implicit none (type, external)
+
+    type(*), dimension(..), contiguous, target, intent(in)    :: sendbuf
+    type(*), dimension(..), contiguous, target, intent(inout) :: recvbuf
+    integer, intent(in)  :: sendcount, sendtype, recvtype, comm
+    integer, intent(in)  :: recvcounts(*), displs(*)
+    integer, intent(out) :: ierror
+
+    ierror = 0
+
+!     displs is measured in elements of recvtype, as MPI defines it.
+
+    call copy_bytes(sendbuf, 0, recvbuf, displs(1) * dt_size(recvtype), &
+                    sendcount * dt_size(sendtype))
+
+  end subroutine MPI_ALLGATHERV
+
+
+  subroutine MPI_SCATTER(sendbuf, sendcount, sendtype, &
+                         recvbuf, recvcount, recvtype, root, comm, ierror)
+
+    implicit none (type, external)
+
+    type(*), dimension(..), contiguous, target, intent(in)    :: sendbuf
+    type(*), dimension(..), contiguous, target, intent(inout) :: recvbuf
+    integer, intent(in)  :: sendcount, sendtype, recvcount, recvtype, root, comm
+    integer, intent(out) :: ierror
+
+    ierror = 0
+
+    call copy_bytes(sendbuf, 0, recvbuf, 0, recvcount * dt_size(recvtype))
+
+  end subroutine MPI_SCATTER
+
+
+  subroutine MPI_SCATTERV(sendbuf, sendcounts, displs, sendtype, &
+                          recvbuf, recvcount, recvtype, root, comm, ierror)
+
+    implicit none (type, external)
+
+    type(*), dimension(..), contiguous, target, intent(in)    :: sendbuf
+    type(*), dimension(..), contiguous, target, intent(inout) :: recvbuf
+    integer, intent(in)  :: sendtype, recvcount, recvtype, root, comm
+    integer, intent(in)  :: sendcounts(*), displs(*)
+    integer, intent(out) :: ierror
+
+    ierror = 0
+
+    call copy_bytes(sendbuf, displs(1) * dt_size(sendtype), recvbuf, 0, &
+                    recvcount * dt_size(recvtype))
+
+  end subroutine MPI_SCATTERV
+
+
+  subroutine MPI_ALLTOALLV(sendbuf, sendcounts, sdispls, sendtype, &
+                           recvbuf, recvcounts, rdispls, recvtype, comm, ierror)
+
+    implicit none (type, external)
+
+    type(*), dimension(..), contiguous, target, intent(in)    :: sendbuf
+    type(*), dimension(..), contiguous, target, intent(inout) :: recvbuf
+    integer, intent(in)  :: sendtype, recvtype, comm
+    integer, intent(in)  :: sendcounts(*), sdispls(*), recvcounts(*), rdispls(*)
+    integer, intent(out) :: ierror
+
+    ierror = 0
+
+!     The only exchange is the block we send to ourselves.
+
+    call copy_bytes(sendbuf, sdispls(1) * dt_size(sendtype), &
+                    recvbuf, rdispls(1) * dt_size(recvtype), &
+                    sendcounts(1) * dt_size(sendtype))
+
+  end subroutine MPI_ALLTOALLV
+
+
+!-----------------------------------------------------------------------
+!     Point to point
+!
+!     Only self-communication is possible here. Puffin uses it for the
+!     periodic field wrap-around, where rank 0 and rank size-1 coincide.
+!     Sends buffer their payload; receives consume the oldest buffered
+!     message carrying a matching tag.
+!-----------------------------------------------------------------------
+
+!> Buffer a message destined for ourselves.
+
+  subroutine enqueue(buf, count, datatype, dest, tag)
+
+    implicit none (type, external)
+
+    type(*), dimension(..), contiguous, target, intent(in) :: buf
+    integer, intent(in) :: count, datatype, dest, tag
+
+    type(pending_msg), allocatable :: grown(:)
+    integer :: nbytes
+
+    if (dest == MPI_PROC_NULL) return
+
+    if (dest /= 0) call serial_abort( &
+      "a message was sent to a rank other than 0, which does not exist.")
+
+    if (.not. allocated(msg_queue)) then
+      allocate(msg_queue(initial_queue_size))
+    else if (n_queued == size(msg_queue)) then
+      allocate(grown(2 * size(msg_queue)))
+      grown(1:n_queued) = msg_queue(1:n_queued)
+      call move_alloc(grown, msg_queue)
+    end if
+
+    nbytes = count * dt_size(datatype)
+
+    n_queued = n_queued + 1
+    msg_queue(n_queued)%tag = tag
+    allocate(msg_queue(n_queued)%payload(max(nbytes, 0)))
+
+    if (nbytes > 0) call copy_bytes(buf, 0, msg_queue(n_queued)%payload, 0, nbytes)
+
+  end subroutine enqueue
+
+
+  subroutine MPI_ISSEND(buf, count, datatype, dest, tag, comm, request, ierror)
+
+    implicit none (type, external)
+
+    type(*), dimension(..), contiguous, target, intent(in) :: buf
+    integer, intent(in)  :: count, datatype, dest, tag, comm
+    integer, intent(out) :: request
+    integer, intent(out) :: ierror
+
+    call enqueue(buf, count, datatype, dest, tag)
+
+!     Buffering completes the send immediately, so the request is already
+!     satisfied by the time it is handed back and MPI_WAIT has nothing to do.
+
+    request = MPI_REQUEST_NULL
+    ierror = 0
+
+  end subroutine MPI_ISSEND
+
+
+  subroutine MPI_SEND(buf, count, datatype, dest, tag, comm, ierror)
+
+    implicit none (type, external)
+
+    type(*), dimension(..), contiguous, target, intent(in) :: buf
+    integer, intent(in)  :: count, datatype, dest, tag, comm
+    integer, intent(out) :: ierror
+
+    call enqueue(buf, count, datatype, dest, tag)
+    ierror = 0
+
+  end subroutine MPI_SEND
+
+
+  subroutine MPI_RECV(buf, count, datatype, source, tag, comm, status, ierror)
+
+    implicit none (type, external)
+
+    type(*), dimension(..), contiguous, target, intent(inout) :: buf
+    integer, intent(in)  :: count, datatype, source, tag, comm
+    integer, intent(out) :: status(MPI_STATUS_SIZE)
+    integer, intent(out) :: ierror
+
+    integer :: i, match, nbytes
+
+    status = 0
+    ierror = 0
+
+    if (source == MPI_PROC_NULL) return
+
+    if (source /= 0) call serial_abort( &
+      "a message was expected from a rank other than 0, which does not exist.")
+
+    match = 0
+    do i = 1, n_queued
+      if (msg_queue(i)%tag == tag) then
+        match = i
+        exit
+      end if
+    end do
+
+    if (match == 0) call serial_abort( &
+      "a receive was posted with no matching message already sent. " // &
+      "In a real MPI run this would have been satisfied by another rank.")
+
+    nbytes = min(count * dt_size(datatype), size(msg_queue(match)%payload))
+
+    if (nbytes > 0) call copy_bytes(msg_queue(match)%payload, 0, buf, 0, nbytes)
+
+!     Consume the message, preserving the order of the ones behind it.
+
+    deallocate(msg_queue(match)%payload)
+    do i = match, n_queued - 1
+      msg_queue(i) = msg_queue(i+1)
+    end do
+    n_queued = n_queued - 1
+
+  end subroutine MPI_RECV
+
+
+!> Sends complete when posted here, so waiting is a no-op.
+
+  subroutine MPI_WAIT(request, status, ierror)
+
+    implicit none (type, external)
+
+    integer, intent(inout) :: request
+    integer, intent(out)   :: status(MPI_STATUS_SIZE)
+    integer, intent(out)   :: ierror
+
+    request = MPI_REQUEST_NULL
+    status = 0
+    ierror = 0
+
+  end subroutine MPI_WAIT
+
+
+  subroutine MPI_WAITALL(count, requests, statuses, ierror)
+
+    implicit none (type, external)
+
+    integer, intent(in)    :: count
+    integer, intent(inout) :: requests(*)
+    integer, intent(out)   :: statuses(MPI_STATUS_SIZE, *)
+    integer, intent(out)   :: ierror
+
+    integer :: i
+
+    do i = 1, count
+      requests(i) = MPI_REQUEST_NULL
+      statuses(:, i) = 0
+    end do
+
+    ierror = 0
+
+  end subroutine MPI_WAITALL
+
+end module mpi

--- a/puffin/lib/backends/serial/puffin_fftw3.f90
+++ b/puffin/lib/backends/serial/puffin_fftw3.f90
@@ -1,0 +1,107 @@
+! Copyright 2012-2018, University of Strathclyde
+! Authors: Lawrence T. Campbell
+! License: BSD-3-Clause
+
+!> @author
+!> Lawrence Campbell,
+!> University of Strathclyde,
+!> Glasgow, UK
+!> @brief
+!> FFTW3 bindings for the serial build.
+!>
+!> Compiled when Puffin is configured with -DENABLE_PARALLEL=OFF. It brings
+!> in the plain (non-MPI) FFTW3 interface from fftw3.f03, and adds the four
+!> fftw_mpi_* entry points that Puffin's transform layer calls, implemented
+!> in terms of their serial counterparts. That keeps transforms.f90 free of
+!> build-mode branching: it goes on calling fftw_mpi_plan_dft_3d and friends
+!> whichever backend is in use, and only libfftw3 is needed to link, not
+!> libfftw3_mpi.
+!>
+!> The mapping is exact for one rank. FFTW-MPI distributes a 3D transform
+!> over the slowest (first, C-order) dimension n0, so on a single process
+!> the local size is the whole array, the offset is zero, and the plan is
+!> an ordinary in-place serial plan over the same dimensions.
+
+module puffin_fftw3
+
+  use, intrinsic :: iso_c_binding, only: C_CHAR, C_DOUBLE, C_DOUBLE_COMPLEX, &
+    C_FLOAT, C_FLOAT_COMPLEX, C_FUNPTR, C_INT, C_INT32_T, C_INTPTR_T, C_PTR, C_SIZE_T
+
+  implicit none (type, external)
+public
+
+  include 'fftw3.f03'
+
+contains
+
+!> No distributed planner to start up.
+
+  subroutine fftw_mpi_init()
+
+    implicit none (type, external)
+
+  end subroutine fftw_mpi_init
+
+
+!> Local data distribution of an n0 x n1 x n2 complex transform. With one
+!> rank the whole transform is local, so the caller allocates the full
+!> array and starts at offset zero.
+
+  integer(C_INTPTR_T) function fftw_mpi_local_size_3d(n0, n1, n2, comm, &
+                                                      local_n0, local_0_start)
+
+    implicit none (type, external)
+
+    integer(C_INTPTR_T), value :: n0
+    integer(C_INTPTR_T), value :: n1
+    integer(C_INTPTR_T), value :: n2
+    integer(C_INT32_T), value :: comm
+    integer(C_INTPTR_T), intent(out) :: local_n0
+    integer(C_INTPTR_T), intent(out) :: local_0_start
+
+    local_n0 = n0
+    local_0_start = 0_C_INTPTR_T
+
+    fftw_mpi_local_size_3d = n0 * n1 * n2
+
+  end function fftw_mpi_local_size_3d
+
+
+!> Plan a 3D complex transform. Dimensions are passed in the same order as
+!> the distributed planner uses, n0 slowest, so this is a straight handover
+!> to the serial planner.
+
+  type(C_PTR) function fftw_mpi_plan_dft_3d(n0, n1, n2, in, out, comm, sign, flags)
+
+    implicit none (type, external)
+
+    integer(C_INTPTR_T), value :: n0
+    integer(C_INTPTR_T), value :: n1
+    integer(C_INTPTR_T), value :: n2
+    complex(C_DOUBLE_COMPLEX), dimension(*), intent(out) :: in
+    complex(C_DOUBLE_COMPLEX), dimension(*), intent(out) :: out
+    integer(C_INT32_T), value :: comm
+    integer(C_INT), value :: sign
+    integer(C_INT), value :: flags
+
+    fftw_mpi_plan_dft_3d = fftw_plan_dft_3d(int(n0, C_INT), int(n1, C_INT), &
+                                            int(n2, C_INT), in, out, sign, flags)
+
+  end function fftw_mpi_plan_dft_3d
+
+
+!> Execute a plan on new arrays.
+
+  subroutine fftw_mpi_execute_dft(p, in, out)
+
+    implicit none (type, external)
+
+    type(C_PTR), value :: p
+    complex(C_DOUBLE_COMPLEX), dimension(*), intent(inout) :: in
+    complex(C_DOUBLE_COMPLEX), dimension(*), intent(out) :: out
+
+    call fftw_execute_dft(p, in, out)
+
+  end subroutine fftw_mpi_execute_dft
+
+end module puffin_fftw3

--- a/puffin/lib/backends/serial/puffin_h5_par.f90
+++ b/puffin/lib/backends/serial/puffin_h5_par.f90
@@ -1,0 +1,76 @@
+! Copyright 2012-2018, University of Strathclyde
+! Authors: Lawrence T. Campbell
+! License: BSD-3-Clause
+
+!> @author
+!> Lawrence Campbell,
+!> University of Strathclyde,
+!> Glasgow, UK
+!> @brief
+!> Parallel-HDF5 entry points for the serial build.
+!>
+!> Compiled when Puffin is configured with -DENABLE_PARALLEL=OFF. HDF5 only
+!> defines h5pset_fapl_mpio_f and h5pset_dxpl_mpio_f when it has itself been
+!> built against MPI, so a serial build cannot import them. It does not need
+!> to either: on one rank the MPI-IO file driver and the default POSIX one
+!> write byte-identical files, and a collective transfer degenerates to an
+!> independent one. So both property-list calls become no-ops here and the
+!> file access and transfer property lists are left at their defaults.
+!>
+!> Everything else in Puffin's HDF5 usage is already serial-safe and is
+!> imported from the HDF5 module as normal. In particular the hyperslab
+!> selections are untouched, so the layout of the files written by a serial
+!> build matches the parallel one exactly.
+
+module puffin_h5_par
+
+  use hdf5, only: HID_T
+
+  implicit none (type, external)
+private
+
+  public :: H5FD_MPIO_COLLECTIVE_F, H5FD_MPIO_INDEPENDENT_F, &
+             h5pset_dxpl_mpio_f, h5pset_fapl_mpio_f
+
+
+!     Data transfer modes. The values are arbitrary - h5pset_dxpl_mpio_f
+!     below is the only thing that ever sees them, and it ignores them.
+
+  integer, parameter :: H5FD_MPIO_INDEPENDENT_F = 0
+  integer, parameter :: H5FD_MPIO_COLLECTIVE_F = 1
+
+contains
+
+!> Would select the MPI-IO file driver. With one rank the default driver
+!> produces the same file, so leave the property list alone.
+
+  subroutine h5pset_fapl_mpio_f(prp_id, comm, info, hdferr)
+
+    implicit none (type, external)
+
+    integer(kind=HID_T), intent(in) :: prp_id
+    integer, intent(in)  :: comm
+    integer, intent(in)  :: info
+    integer, intent(out) :: hdferr
+
+    hdferr = 0
+
+  end subroutine h5pset_fapl_mpio_f
+
+
+!> Would set collective or independent transfer. Both mean the same thing
+!> when there is only one rank taking part.
+
+  subroutine h5pset_dxpl_mpio_f(prp_id, data_xfer_mode, hdferr)
+
+    implicit none (type, external)
+
+    integer(kind=HID_T), intent(in) :: prp_id
+    integer, intent(in)  :: data_xfer_mode
+    integer, intent(out) :: hdferr
+
+    hdferr = 0
+
+  end subroutine h5pset_dxpl_mpio_f
+
+end module puffin_h5_par

--- a/puffin/lib/common/puffin_fftwInfo.f90
+++ b/puffin/lib/common/puffin_fftwInfo.f90
@@ -5,17 +5,19 @@
 module puffin_fftwInfo
 
    use puffin_kinds, only: ip
-   use, intrinsic :: iso_c_binding, only: C_CHAR, C_DOUBLE, C_DOUBLE_COMPLEX, &
-     C_FLOAT, C_FLOAT_COMPLEX, C_FUNPTR, C_INT, C_INT32_T, C_INTPTR_T, C_PTR, C_SIZE_T
+!  The FFTW3 bindings come from a build-mode-specific backend: the real
+!  FFTW3-MPI interface for a parallel build, or plain FFTW3 plus one-rank
+!  fftw_mpi_* shims for a serial one. See puffin/lib/backends.
+   use puffin_fftw3, only: fftw_alloc_complex, FFTW_BACKWARD, fftw_destroy_plan, &
+     FFTW_ESTIMATE, FFTW_FORWARD, fftw_free, FFTW_MEASURE, fftw_mpi_execute_dft, &
+     fftw_mpi_init, fftw_mpi_local_size_3d, fftw_mpi_plan_dft_3d
+   use, intrinsic :: iso_c_binding, only: C_INTPTR_T, C_PTR
    implicit none (type, external)
 private
 
 public :: fftw_alloc_complex, FFTW_BACKWARD, fftw_destroy_plan, FFTW_ESTIMATE, FFTW_FORWARD, &
            fftw_free, FFTW_MEASURE, fftw_mpi_execute_dft, fftw_mpi_init, fftw_mpi_local_size_3d, &
            fftw_mpi_plan_dft_3d, tTransInfo_G
-
-
-   include 'fftw3-mpi.f03'
 
 !-----------------------------------------------------------------
 ! Author - Lawrence Campbell

--- a/puffin/lib/io/h5_in.f90
+++ b/puffin/lib/io/h5_in.f90
@@ -16,11 +16,12 @@ use paraField, only: fr_rfield, bk_rfield, ac_rfield, fr_ifield, bk_ifield, ac_i
   mainlen, ffs, tlflen, ees, tlelen, qStart_new, getlocalfieldindices
 use HDF5, only: h5aclose_f, h5aopen_f, H5Aopen_name_f, h5aread_f, h5close_f, h5dclose_f, &
   h5Dget_space_f, h5dget_type_f, h5dopen_f, h5dread_f, H5F_ACC_RDONLY_F, h5fclose_F, &
-  H5FD_MPIO_COLLECTIVE_F, h5fopen_f, h5gclose_f, h5gopen_f, h5open_f, H5P_DATASET_XFER_F, &
-  H5P_FILE_ACCESS_F, h5pclose_f, h5pcreate_f, h5pset_dxpl_mpio_f, h5pset_fapl_mpio_f, &
+  h5fopen_f, h5gclose_f, h5gopen_f, h5open_f, H5P_DATASET_XFER_F, H5P_FILE_ACCESS_F, &
+  h5pclose_f, h5pcreate_f, &
   H5S_SELECT_SET_F, h5sclose_f, h5screate_simple_f, h5Sget_simple_extent_dims_f, &
   h5Sget_simple_extent_ndims_f, h5sselect_hyperslab_f, H5T_FLOAT_F, H5T_NATIVE_DOUBLE, &
   H5T_NATIVE_INTEGER, h5tclose_f, h5tcopy_f, h5tget_class_f, HID_T, HSIZE_T
+use puffin_h5_par, only: H5FD_MPIO_COLLECTIVE_F, h5pset_dxpl_mpio_f, h5pset_fapl_mpio_f
 use GlobalTypes, only: tSimulationFlags, tFELFrame
 use mpi, only: MPI_ALLREDUCE, mpi_barrier, MPI_COMM_WORLD, MPI_INFO_NULL, MPI_INTEGER, MPI_SUM
 

--- a/puffin/lib/io/hdf5_puff_coll.f90
+++ b/puffin/lib/io/hdf5_puff_coll.f90
@@ -16,9 +16,8 @@ module hdf5PuffColl
 use puffin_kinds, only: WP, IP
 use hdf5, only: h5aclose_f, h5acreate_f, h5awrite_f, h5close_f, h5dclose_f, h5dcreate_f, &
   h5dget_space_f, h5dopen_f, h5dwrite_f, H5F_ACC_RDWR_F, H5F_ACC_TRUNC_F, h5fclose_f, &
-  h5fcreate_f, H5FD_MPIO_COLLECTIVE_F, H5FD_MPIO_INDEPENDENT_F, h5fopen_f, h5gclose_f, &
-  h5gcreate_f, h5open_f, H5P_DATASET_XFER_F, H5P_FILE_ACCESS_F, h5pclose_f, h5pcreate_f, &
-  h5pset_dxpl_mpio_f, h5pset_fapl_mpio_f, H5S_SCALAR_F, H5S_SELECT_SET_F, h5sclose_f, &
+  h5fcreate_f, h5fopen_f, h5gclose_f, h5gcreate_f, h5open_f, H5P_DATASET_XFER_F, &
+  H5P_FILE_ACCESS_F, h5pclose_f, h5pcreate_f, H5S_SCALAR_F, H5S_SELECT_SET_F, h5sclose_f, &
   h5screate_f, h5screate_simple_f, h5sselect_hyperslab_f, h5sselect_none_f, &
   H5T_NATIVE_CHARACTER, H5T_NATIVE_DOUBLE, H5T_NATIVE_INTEGER, H5T_STR_SPACEPAD_F, h5tclose_f, &
   h5tcopy_f, h5tset_size_f, h5tset_strpad_f, HID_T, HSIZE_T
@@ -34,6 +33,8 @@ use hdf5PuffLow, only: addh5stringattribute, addh5derivedvariable, write3dlimgrp
   integertostring
 use GlobalTypes, only: tSimulationContext
 use ParaField, only: qUnique
+use puffin_h5_par, only: H5FD_MPIO_COLLECTIVE_F, H5FD_MPIO_INDEPENDENT_F, &
+  h5pset_dxpl_mpio_f, h5pset_fapl_mpio_f
 use mpi, only: MPI_INFO_NULL
 
 implicit none (type, external)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -176,33 +176,47 @@ add_pfunit_ctest (puffin_basic_tests
   LINK_LIBRARIES puffin_mpi
 )
 
+# The integration suites below are declared @mpitest(npes=[2]), so they need a
+# real MPI to launch under. A serial build (-DENABLE_PARALLEL=OFF) gets
+# puffin_e2e_tests_serial instead, which drives the same 1D deck in-process on
+# one rank. See doc/SERIAL_BUILD.md.
+if (ENABLE_PARALLEL)
 
-add_pfunit_ctest (puffin_e2e_tests
-  TEST_SOURCES testMPIIntegration.pf
-  LINK_LIBRARIES puffin_mpi
-  MAX_PES 2
-)
+  add_pfunit_ctest (puffin_e2e_tests
+    TEST_SOURCES testMPIIntegration.pf
+    LINK_LIBRARIES puffin_mpi
+    MAX_PES 2
+  )
 
-# As with the 3D test, its own binary so puffin's global allocatables are clean
-add_pfunit_ctest (puffin_e2e_tests_1d_taper
-  TEST_SOURCES testMPIIntegration1DTaper.pf
-  LINK_LIBRARIES puffin_mpi
-  MAX_PES 2
-)
+  # As with the 3D test, its own binary so puffin's global allocatables are clean
+  add_pfunit_ctest (puffin_e2e_tests_1d_taper
+    TEST_SOURCES testMPIIntegration1DTaper.pf
+    LINK_LIBRARIES puffin_mpi
+    MAX_PES 2
+  )
 
-# 3D test gets its own binary so puffin's global allocatables are clean
-add_pfunit_ctest (puffin_e2e_tests_3d
-  TEST_SOURCES testMPIIntegration3D.pf
-  LINK_LIBRARIES puffin_mpi
-  MAX_PES 2
-)
+  # 3D test gets its own binary so puffin's global allocatables are clean
+  add_pfunit_ctest (puffin_e2e_tests_3d
+    TEST_SOURCES testMPIIntegration3D.pf
+    LINK_LIBRARIES puffin_mpi
+    MAX_PES 2
+  )
+
+else()
+
+  add_pfunit_ctest (puffin_e2e_tests_serial
+    TEST_SOURCES testSerialIntegration.pf
+    LINK_LIBRARIES puffin_mpi
+  )
+
+endif()
 
 
 
 # Slow full-lattice 3D test — gated by CMake option, not run by default
 option(PUFFIN_SLOW_TESTS "Build slow integration tests (full CLARA 17-module lattice, ~30s and ~750 HDF5 dumps)" OFF)
 
-if(PUFFIN_SLOW_TESTS)
+if(PUFFIN_SLOW_TESTS AND ENABLE_PARALLEL)
 
   configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/inputs/3D/clara_full.in"
@@ -285,7 +299,7 @@ endif()
 option(PUFFIN_BIG_TESTS "Build big integration tests (85x85x5780 field mesh, ~9-12GB RAM and ~9 min at 6 ranks)" OFF)
 set(PUFFIN_BIG_TEST_PES 6 CACHE STRING "MPI ranks used by the big 3D integration test")
 
-if(PUFFIN_BIG_TESTS)
+if(PUFFIN_BIG_TESTS AND ENABLE_PARALLEL)
 
   configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/inputs/3D/shcse_big.in"
@@ -350,6 +364,17 @@ if(PUFFIN_BIG_TESTS)
   add_executable(harvest_big_reference harvest_big_reference.f90)
   target_link_libraries(harvest_big_reference puffin_mpi)
 
+endif()
+
+# Both gated suites are declared @mpitest, so a serial build cannot run them
+# even when the option is on. Say so rather than silently building nothing.
+if (NOT ENABLE_PARALLEL)
+  if (PUFFIN_SLOW_TESTS)
+    message(STATUS "PUFFIN_SLOW_TESTS ignored: the slow suite is @mpitest and needs ENABLE_PARALLEL=ON")
+  endif()
+  if (PUFFIN_BIG_TESTS)
+    message(STATUS "PUFFIN_BIG_TESTS ignored: the big suite is @mpitest and needs ENABLE_PARALLEL=ON")
+  endif()
 endif()
 
 # ^^ For examples of adding more tests, see:

--- a/test/testSerialIntegration.pf
+++ b/test/testSerialIntegration.pf
@@ -1,0 +1,163 @@
+!> This test module tests a serial build of Puffin (-DENABLE_PARALLEL=OFF) by
+!! running a complete 1D FEL simulation in-process and validating the results
+!! against the same golden files the parallel integration test uses.
+!!
+!! It is the serial counterpart of testMPIIntegration, and deliberately checks
+!! the same deck against the same references. Those references were captured
+!! from a two-rank run, so agreeing with them to 1e-10 is the statement that
+!! matters: turning MPI off must not change the physics. The backend modules
+!! in puffin/lib/backends/serial stand in for MPI, FFTW3-MPI and parallel
+!! HDF5 with one-rank semantics, and this is what holds them to that.
+!!
+!! Only built when ENABLE_PARALLEL is OFF - see test/CMakeLists.txt. The
+!! parallel suites cannot stand in for it, because they are declared
+!! @mpitest and so never exercise the serial backend at all.
+
+module testSerialIntegration
+
+  use pFUnit
+  use puffin_kinds
+  use puffin_mod, only: puffin_main
+  use H5in, only: getMacroparticleCount, readH5BeamDataOntoRootProcess, &
+                  readH5FieldDataOntoRootProcess, getNZ2, getWriteStep
+  use globals
+  use puffin_mpiInfo, only: tProcInfo_G
+  implicit none
+
+  character(len=1024_IP) :: test_file_1 = 'inputs/f1main.in'
+  character(len=1024_ip) :: output_file_base = 'inputs/f1main'
+
+contains
+
+  !! Test that a serial Puffin simulation runs and reproduces the reference
+
+  @test
+  subroutine testSerialPuffinSimulationCompletes()
+
+    logical :: file_exists, qOK
+    character(len=1024_ip) :: test_output_field_initial_file, &
+                              test_output_electron_initial_file, &
+                              test_output_integrated_initial_file, &
+                              test_output_field_final_file, &
+                              test_output_electron_final_file, &
+                              test_output_integrated_final_file, &
+                              expected_field_file, &
+                              expected_electron_file, &
+                              expected_integrated_file
+    integer(kind=ip) :: nMPs, i
+    real(kind=WP), allocatable :: sElX(:), sElY(:), sElZ2(:), sElPX(:), sElPY(:), sElGam(:), chi_bar(:)
+    real(kind=WP) :: expected_sElZ2(319), &
+                     expected_sElGam(319), &
+                     expected_sElX(319), &
+                     expected_sElY(319), &
+                     expected_sElPx(319), &
+                     expected_sElPY(319), &
+                     expected_chi_bar(319)
+    integer(kind=ip) :: nZ2nodes
+    real(kind=WP), allocatable :: rfield(:), ifield(:)
+    real(kind=WP) :: expected_rfield(511), expected_ifield(511)
+
+    ! f1main.in runs a single undulator module of nPeriods=1 at
+    ! stepsPerPeriod=30, so the run finishes on step 30.
+    integer(kind=ip), parameter :: nStepsFinal = 30_ip
+
+    print *, 'Testing serial Puffin simulation completion...'
+
+    call puffin_main(test_file_1, qOK)
+
+    ! A serial build is a single rank, and that rank is the root. If this ever
+    ! came out false the checks below would silently stop testing anything.
+    @AssertTrue(tProcInfo_G%qRoot)
+    @AssertEqual(tProcInfo_G%size, 1)
+
+    ! Verify successful execution
+    ! Indices below are output file indices, not steps. The counter advances
+    ! once per dump, and this deck dumps three times: at step 0, at the end of
+    ! the undulator module (step 30), and again for the qDumpEnd_G write. Only
+    ! the first and last of those produce full aperp/electrons files, so the
+    ! final full dump lands at index 2 while integrated runs 0, 1, 2.
+    test_output_field_initial_file = trim(output_file_base) // "_aperp_0.h5"
+    test_output_electron_initial_file = trim(output_file_base) // '_electrons_0.h5'
+    test_output_integrated_initial_file = trim(output_file_base) // '_integrated_0.h5'
+
+    test_output_field_final_file = trim(output_file_base) // '_aperp_2.h5'
+    test_output_electron_final_file = trim(output_file_base) // '_electrons_2.h5'
+    test_output_integrated_final_file = trim(output_file_base) // '_integrated_2.h5'
+
+    expected_field_file = 'expected/f1main_expected_field.h5'
+    expected_electron_file = 'expected/f1main_expected_electrons.h5'
+    expected_integrated_file = 'expected/f1main_expected_integrated.h5'
+
+    inquire(file=test_output_field_initial_file, exist=file_exists)
+    @AssertTrue(file_exists)
+
+    inquire(file=test_output_electron_initial_file, exist=file_exists)
+    @AssertEqual(file_exists, .true.)
+
+    nMPs = getMacroparticleCount(trim(test_output_electron_final_file))
+
+    @AssertEqual(nMPs, 319_ip)
+
+    allocate(sElX(nMPs), sElY(nMPs), sElZ2(nMPs), sElPX(nMPs), sElPY(nMPs), sElGam(nMPs), chi_bar(nMPs))
+    call readH5BeamDataOntoRootProcess(trim(test_output_electron_final_file), &
+      sElX, sElY, sElZ2, sElPX, sElPY, sElGam, chi_bar, nMPs)
+    call readH5BeamDataOntoRootProcess(trim(expected_electron_file), &
+      expected_sElX, expected_sElY, expected_sElZ2, expected_sElPX, expected_sElPY, expected_sElGam, expected_chi_bar, nMPs)
+
+    ! The reference was captured from a two-rank run, where the macroparticles
+    ! can come out of the collective write in a different order. So check that
+    ! each value produced here matches some expected value, as the parallel
+    ! test does, rather than pinning the ordering.
+
+    do i = 1, nMPs
+      @AssertTrue(ANY( ABS(expected_sElX-sElX(i)) <= 1e-10_WP))
+      @AssertTrue(ANY( ABS(expected_sElY-sElY(i)) <= 1e-10_WP))
+      @AssertTrue(ANY( ABS(expected_sElZ2-sElZ2(i)) <= 1e-10_WP))
+      @AssertTrue(ANY( ABS(expected_sElPX-sElPX(i)) <= 1e-10_WP))
+      @AssertTrue(ANY( ABS(expected_sElPY-sElPY(i)) <= 1e-10_WP))
+      @AssertTrue(ANY( ABS(expected_sElGam-sElGam(i)) <= 1e-10_WP))
+    end do
+
+    ! Test radiation field nodes
+    nZ2nodes = getNZ2(trim(test_output_field_final_file))
+
+    print *, "Number of Z2 nodes in field file: ", nZ2nodes
+    @AssertEqual(nZ2nodes, 511_ip)
+    @AssertEqual(nZ2nodes, size(expected_rfield))
+    @AssertEqual(nZ2nodes, size(expected_ifield))
+
+    allocate(rfield(nZ2nodes), ifield(nZ2nodes))
+    call readH5FieldDataOntoRootProcess(trim(test_output_field_final_file), rfield, ifield, nZ2nodes)
+    call readH5FieldDataOntoRootProcess(trim(expected_field_file), expected_rfield, expected_ifield, nZ2nodes)
+
+    @AssertEqual(rfield, expected_rfield, 1e-10_WP)
+    @AssertEqual(ifield, expected_ifield, 1e-10_WP)
+
+    inquire(file=test_output_integrated_initial_file, exist=file_exists)
+    @AssertEqual(file_exists, .true.)
+
+    inquire(file=test_output_field_final_file, exist=file_exists)
+    @AssertEqual(file_exists, .true.)
+
+    inquire(file=test_output_electron_final_file, exist=file_exists)
+    @AssertEqual(file_exists, .true.)
+
+    inquire(file=test_output_integrated_final_file, exist=file_exists)
+    @AssertEqual(file_exists, .true.)
+
+    ! The dumps must land at the step each index claims to hold, not merely
+    ! exist. The output file index is advanced once per dump, so anything that
+    ! rewinds it silently overwrites an earlier index with later data --
+    ! index 0 is the only record of the initial state of the run.
+
+    @AssertEqual(getWriteStep(trim(test_output_integrated_initial_file)), 0_ip)
+    @AssertEqual(getWriteStep(trim(test_output_field_initial_file)), 0_ip)
+    @AssertEqual(getWriteStep(trim(test_output_electron_initial_file)), 0_ip)
+
+    @AssertEqual(getWriteStep(trim(test_output_integrated_final_file)), nStepsFinal)
+    @AssertEqual(getWriteStep(trim(test_output_field_final_file)), nStepsFinal)
+    @AssertEqual(getWriteStep(trim(test_output_electron_final_file)), nStepsFinal)
+
+  end subroutine testSerialPuffinSimulationCompletes
+
+end module testSerialIntegration


### PR DESCRIPTION
Adds a serial build mode. `-DENABLE_PARALLEL=OFF` produces an executable that
runs directly, needs no launcher, and links neither `libmpi` nor
`libfftw3_mpi`:

```sh
cmake -B ../build-serial -DENABLE_PARALLEL=OFF .
cmake --build ../build-serial
../build-serial/puffin/puffin my_deck.in     # no mpirun
```

It is for debugging (`gdb ./puffin` rather than attaching to a rank), for
profiling and single-core benchmarking, for machines with no MPI installed, and
for isolating whether a problem is in the physics or in the domain
decomposition. It is not a performance feature — a serial build puts all the
work and all the memory on one core, and production runs still want MPI.

## Approach

The obvious way to do this is to conditionally compile the MPI calls out of the
physics, setup and IO code. That is about 250 call sites across 15 files, and
it would also be wrong: on one rank a barrier or a broadcast really is nothing,
but `MPI_ALLREDUCE(send, recv, ...)` still has to copy send→recv,
`MPI_ALLGATHERV` still has to copy to the right displacement, and the periodic
field wrap-around in `para_field.f90` posts an `MPI_ISSEND` **to itself** and
then receives it — rank 0 and rank `size-1` are the same process when
`size == 1`. Deleting those calls would produce plausible but wrong physics.

So this goes the other way round: every call site stays exactly as it is, and
the thing underneath is swapped. Puffin already imports MPI as
`use mpi, only: ...`, so a module literally named `mpi` with one-rank semantics
slots straight in. CMake compiles one of two backend directories:

```
puffin/lib/backends/mpi/      when ENABLE_PARALLEL=ON
puffin/lib/backends/serial/   when ENABLE_PARALLEL=OFF
```

Both define the same module names — `mpi`, `puffin_fftw3`, `puffin_h5_par` —
with the same public interfaces, so which one was built is invisible to
everything downstream. **There are no preprocessor conditionals anywhere, and
the only change to existing Fortran is three `use` lines.** The backends sit two
levels below `lib/`, so the existing source globs never pick up both.

### `mpi` (`backends/serial/mpi_serial.f90`)

Exports the subset of the MPI-3 Fortran API Puffin uses, for a communicator of
size 1:

- `MPI_COMM_SIZE` returns 1, `MPI_COMM_RANK` returns 0.
- Barriers, waits, `MPI_BCAST`, init and finalize are no-ops.
- Reductions, gathers, scatters and all-to-alls copy the send buffer to the
  receive buffer at the displacement MPI defines, or do nothing when the caller
  passes `MPI_IN_PLACE` — detected by address, as real MPI does.
- Sends and receives work **to and from ourselves**, through a small FIFO of
  buffered messages, which is what the periodic mesh needs.
- Anything that can only mean something on more than one rank — a send to a
  rank that does not exist, a receive with no matching message already posted —
  stops the run with a diagnostic rather than silently skipping a real
  communication.

Buffer arguments are `type(*), dimension(..)` (assumed-type, assumed-rank), so
one implementation serves every type and rank Puffin passes, mirroring the
`<type> buf(*)` of the real Fortran bindings.

### `puffin_fftw3`

Adds the four `fftw_mpi_*` entry points the transform layer calls on top of
plain FFTW3. FFTW-MPI distributes a 3D transform over the slowest dimension, so
on one rank the local size is the whole array, the offset is zero, and the plan
is an ordinary in-place serial plan over the same dimensions. `transforms.f90`
is unchanged. `FindFFTW3.cmake` gained an `MPI` component so only a parallel
configure links `libfftw3_mpi`.

### `puffin_h5_par`

`h5pset_fapl_mpio_f` and `h5pset_dxpl_mpio_f` become no-ops, leaving the
property lists at their defaults — on one rank the MPI-IO driver and the
default POSIX one write byte-identical files, and a collective transfer
degenerates to an independent one. Hyperslab selections are untouched, so the
file layout matches the parallel build exactly. HDF5 only defines these names
when built against MPI, so `h5_in.f90` and `hdf5_puff_coll.f90` now import them
from here instead of from `hdf5`.

## Verification

Serial output against `mpirun -n 1` of the parallel build, on the committed
decks:

| Deck | Result |
| --- | --- |
| `f1main.in` (1D) | field, electrons and integrated data **bit-exact** |
| `osc_taper.in` (1D, periodic mesh, 5 modules — the self-send path) | field and electrons **bit-exact** |
| `clara_test.in` (3D, periodic mesh, diffraction) | electrons **bit-exact**; field agrees to 4e-15 relative |

The 3D field is not bit-exact because FFTW's serial and MPI planners pick
different codelets for the same transform and so sum in a different order. Max
absolute difference 5.3e-18 against a field maximum of 1.3e-3 — four orders of
magnitude inside the 1e-10 E2E tolerance.

Where a serial run differs from the *two-rank* golden files, `mpirun -n 1` of
the parallel build was checked to differ in exactly the same way. That is the
pre-existing rank-count dependence, not something this introduces.

## Testing

- Parallel build: all four existing suites pass, unchanged.
- Serial build: `puffin_basic_tests` plus a new `puffin_e2e_tests_serial`
  (`test/testSerialIntegration.pf`), which runs the full 1D `f1main` deck
  in-process and checks it against the same golden files the parallel
  integration test uses. Those references came from a two-rank run, so agreeing
  with them to 1e-10 is the statement that matters.
- The `@mpitest` suites, including the opt-in slow and big tiers, are built only
  for a parallel configure.
- Benchmarks work in serial for the single-rank case (`--serial` runs the
  executable directly). For interest, `1d_serial` in a Debug build: 23.2 s
  serial against 25.4 s under `mpirun -n 1`.
- `-DENABLE_LINT=ON` is clean on the new sources.

## Notes for reviewers

- If the HDF5 CMake finds is itself a parallel build, linking it still pulls
  `libmpi` in transitively. The executable is still launched directly and never
  calls MPI, but the binary is not MPI-free; `HDF5_ROOT` can point at a serial
  HDF5. CMake says so at configure time.
- Adding a new MPI call anywhere in Puffin now also means adding its one-rank
  meaning to `backends/serial/mpi_serial.f90`, or the serial build stops
  compiling. That is deliberate — it fails loudly rather than quietly. Noted in
  `CLAUDE.md`.
- Full write-up in `doc/SERIAL_BUILD.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016C9yaSCzMkp6jofdYhq3d8
