### PR TITLE
Add an opt-in period-averaged (SVEA) solver mode, in 1D

### DIFF
--- a/AVERAGED_MODE_ROADMAP.md
+++ b/AVERAGED_MODE_ROADMAP.md
@@ -1,0 +1,163 @@
+# Period-Averaged Mode — Programme of Work
+
+## Overview
+
+The period-averaged (SVEA) solver mode, `qAveraged`, stores the radiation as a slowly
+varying envelope about the resonant carrier and averages the electron equations over an
+undulator period. It exists to make runs cheap where averaging is valid: on the 1D
+validation deck it is 9.3x faster than the unaveraged solver at its own settings, and
+closer to the converged answer.
+
+**Current state:** 1D only, helical or linearly polarised undulators only, single band.
+Implemented and validated on `feature/period-averaged`. The default (unaveraged) path is
+byte-identical to `dev`.
+
+**Governing constraint:** this is a *mode*, never a replacement. The unaveraged solver is
+Puffin's reason to exist; every change here must leave it bit-exact.
+
+Design notes live in `puffin/lib/undulator/averaging.f90` and the "Period-Averaged Mode"
+section of `doc/manual.tex`. The accuracy map and its harness are in `benchmark/averaged/`.
+
+---
+
+## Status summary
+
+| # | Workstream | Status | Depends on | Issue |
+|---|------------|--------|-----------|-------|
+| W1 | Land the 1D mode on `dev` | Ready to submit — decision needed | — | — |
+| W2 | 3D | Not started | — | — |
+| W3 | Multiple field arrays (elliptical + harmonics) | Not started | #107 (ideally) | #129 |
+| W4 | Compatibility: periodic mesh, lattices, restart | Not started | — | — |
+| W5 | Diagnostics, dump metadata and viz tools | Not started | W2 for 3D views | — |
+| W6 | Finish the accuracy map | Partly done | W3 for harmonics | #130 |
+| W7 | Housekeeping: buffer bug, benchmarks, defaults | Partly done | — | #128 |
+
+---
+
+## Invariants
+
+Anything below must preserve these, and they are cheap to check:
+
+1. **Default path bit-exact.** Verified by running a deck against a pristine `dev` build and
+   comparing `/aperp` and `/power` byte for byte, plus all four `ctest` suites.
+2. **Energy conservation by construction.** The coupling is one per-particle `ptilde` array
+   shared between `getSource_*` and `dgamdz_f`; `test/testAveraging.pf` checks the balance
+   through the real `getrhs` to 1e-13. Any new band or component must be added the same way.
+3. **z2 stays the macroparticle coordinate**, with the ponderomotive phase computed on the
+   fly, so the parallel decomposition, buffers, HDF5 chain and diagnostics keep working.
+4. **Opt-in, and loudly rejected where invalid** rather than silently wrong.
+
+---
+
+## W1 — Land the 1D mode
+
+Everything for a PR against `dev` is in place: opt-in, default bit-exact, unit and e2e suites
+passing, manual and benchmark documentation written. The open ~1% planar residual is
+documented and tracked (#130, #129) rather than unknown.
+
+**Decision:** submit now and treat 3D and the rest as follow-ups, or hold the PR until the
+residual is understood. Submitting now keeps the diff reviewable — it is already 22 files —
+and lets 3D build on a merged base.
+
+## W2 — 3D
+
+Largest single piece of user value, and independent of W3.
+
+- **Averaged natural focusing.** In 1D `bz = 0` and the slow transverse momentum is constant.
+  In 3D the natural focusing arises from the quiver beating against `bz` and the off-axis
+  field variation; that product has to be averaged analytically, giving a betatron term in
+  `dppdz` rather than the current zero.
+- **Diffraction carrier offset.** `multiplyexp` in `diffraction.f90` applies
+  `exp(i h (kx^2+ky^2) / 2 kz2)`. With the field stored as an envelope, the physical
+  wavenumber is `kz2_envelope - 1/2rho`. Offsetting rather than freezing `kz2` at the
+  carrier keeps diffraction frequency-dependent across the band, which is better than the
+  usual averaged-code treatment — worth doing deliberately and documenting.
+- **Filter semantics.** `qFilter`'s cutoff is defined on physical `kz2`; decide what it means
+  in envelope coordinates (in band terms it will usually be inert) and document it.
+- Lift the 3D rejection in `chkAveraged` (`puffin/lib/setup/checks.f90`). `getSource_3D` is
+  already wired for the averaged coupling.
+- **Tests:** extend the `getrhs` energy-balance test to the 3D path; validate against
+  `test/inputs/3D/clara_test.in`. Note `benchmark/averaged/compare.py` is 1D-only and will
+  need a 3D comparison (integrated power plus transverse profile).
+
+## W3 — Multiple field arrays
+
+Elliptical undulators and harmonic bands are the same structural problem: more than one
+envelope. Doing them as one generalisation is much cheaper than twice.
+
+- **General elliptical.** A single envelope is exact only for helical (`u+ = 0`) or linear
+  (`|u+| = |u-|`); elliptical needs the two helicity components as independent envelopes,
+  since their coupling ratios differ. Currently rejected at setup and in `UndSection`.
+- **Harmonic bands (#129).** An extra envelope per odd harmonic, carrier `exp(-i h z2/2rho)`,
+  coupling `JJ_h = J_((h-1)/2)(h xi) - J_((h+1)/2)(h xi)`, reducing to today's `J0 - J1` at
+  `h = 1`. Recovers both the missing harmonic output (~2% of radiated power at aw ~ 1) and
+  the harmonics' drive on `dGamma/dz`.
+- **Sequencing:** both want the field storage to be an object rather than loose module
+  arrays, which is exactly #107 (`tFieldValues`). Doing #107 first will make this much less
+  invasive.
+- **Acceptance:** energy balance summed over components; elliptical reproduces helical and
+  planar as limiting cases; harmonic power compares like-for-like against an unaveraged run.
+
+## W4 — Compatibility
+
+Each of these is mostly a test, and each may turn up a guard that needs writing.
+
+- **Periodic mesh** (`meshType = 1`). Untested in averaged mode. Watch the interaction
+  between the periodic wrap (`bz2PB`) and the averaged mode's exact buffer bound in
+  `calcBuff`. Testbeds: `test/inputs/1D/osc_taper.in`, `inputs/simple/3D/CLARA/single-slice/`.
+- **Lattices and multiple modules.** Drifts, chicanes, quads and modulations all act on z2 and
+  the slow momentum, so they should be correct as-is — but the ponderomotive phase restarts
+  with each module's local zbar, exactly as the unaveraged quiver does, and that equivalence
+  should be demonstrated on a multi-module deck rather than assumed.
+- **Restart and HDF5 input.** `qResume`, `iReadH5Field`, MASP and HDF5 beam input are
+  currently unguarded: a resolved field read into an envelope array, or a `pperp` that still
+  contains the quiver, would be silently wrong. Either convert on read (demodulate the field,
+  subtract the quiver) or reject with a clear message. Rejection first, conversion later.
+- **Far-from-resonance decks.** Two-colour and strongly tapered cases violate the premise that
+  `dtheta/dzbar = (1 - p2)/2rho` is slow; they need either multiple carriers or a detuning
+  check that warns. Note `osc_taper` is both periodic and tapered.
+
+## W5 — Diagnostics, metadata and viz
+
+- **Write averaged-mode metadata into the dumps** (`qAveraged`, `lambdarPerCell`, carrier
+  wavenumber). Cheap, and it is what lets every downstream tool adapt instead of guessing.
+  Worth doing early, independently of the rest.
+- **Viz tools** (`utilities/pyPlotting/`: `puffin_viz_data.py`, `viewField1D_bokeh.py`,
+  `viewField3D_bokeh.py`, player and theme). In averaged mode the field arrays hold an
+  envelope: there is no carrier oscillation to plot, spectra are about the carrier rather
+  than absolute, and a "reconstruct the resolved field" view may be worth offering. Power is
+  already consistent, because the envelope is normalised so `|Atilde|^2` is the period
+  average of `|A_perp|^2`.
+- **Electron dumps.** `pperp` holds only its slow part in averaged mode — correct, and
+  arguably more useful (it is the betatron momentum), but it must be labelled.
+
+## W6 — Finish the accuracy map
+
+- **rho scan (#130)** — deferred; characterises the ~1% planar remainder.
+- **Harmonic back-action** — needs W3 before it can be separated from the above.
+- **Model the dropped A-term.** The radiation-driven transverse momentum accounts for ~0.55%
+  in both polarisations. Its slow effect on p2 can be added analytically, removing a known
+  error rather than documenting it.
+- **A deck that can discriminate cell size.** The current deck is seeded, narrow band and flat
+  top, so it cannot justify cells coarser than 1-2 wavelengths. SASE, or sharp current
+  gradients, would also exercise what averaging gives up (coherent spontaneous emission).
+
+## W7 — Housekeeping
+
+- **#128** — `calcBuff` rounds the field buffer short; fixed in averaged mode only, because
+  fixing it generally shifts e2e goldens at the 1e-10 level. Also: a failed rearrangement
+  exits with status 0.
+- **Benchmarks and defaults.** Add an averaged case to the benchmark suite. The cheapest
+  converged setting on the validation deck is `stepsPerPeriod = 1`, `lambdarPerCell = 1`.
+
+---
+
+## Suggested order
+
+1. **W1** — land 1D, so later work builds on a merged base.
+2. **W7 + the metadata item from W5** — cheap, and they unblock coarse meshes and the viz work.
+3. **W2** — 3D.
+4. **W4** — compatibility and guards; mostly tests, and they protect users from silent wrongness.
+5. **#107, then W3** — multiple field arrays: elliptical first (simpler, two components), then
+   harmonic bands.
+6. **W6** — close out the accuracy map, once W3 makes the harmonic question answerable.

--- a/benchmark/averaged/.gitignore
+++ b/benchmark/averaged/.gitignore
@@ -1,0 +1,2 @@
+run_*/
+__pycache__/

--- a/benchmark/averaged/README.md
+++ b/benchmark/averaged/README.md
@@ -1,0 +1,157 @@
+# Averaged vs unaveraged
+
+`run_compare.py` runs the period-averaged mode (`qAveraged`, see
+`puffin/lib/undulator/averaging.f90` and the "Period-Averaged Mode" section of
+`doc/manual.tex`) and the ordinary unaveraged solver on the same 1D deck, and
+compares them.
+
+```sh
+python3 run_compare.py helical                        # defaults: --plain 12:30 24:60 48:120 --avg 1:2
+python3 run_compare.py planepole --plain 48:120 96:240
+python3 run_compare.py planepole --aw 0.5
+python3 compare.py <plain_dir> <avg_dir> 0.005 helical   # full envelope and power tables
+python3 compare_avg.py <avg_ref_dir> <avg_dir> ...       # averaged against averaged
+```
+
+The unaveraged field is demodulated onto the averaged envelope's normalisation
+(the `exp(-i z2/2rho)` component, averaged over exactly one resonant wavelength)
+and compared node by node; power is compared as the flat-top mean of `/power`.
+Note that `/power` sums every frequency the mesh resolves, so for a planar
+undulator it includes harmonic radiation that the averaged mode cannot carry -
+see the harmonic decomposition below. The one-wavelength box used for the
+demodulation has exact nulls at every harmonic, so `demod` isolates the
+fundamental band.
+
+The deck is the CLARA-like 1D one used for `benchmark/convergence` (rho =
+0.005, aw = 1.012, gamma_r = 456.4), seeded, noise-free, 60 periods - about
+3.8 gain lengths, still in the exponential regime. Needs `mpirun` and
+`h5dump`; standard library Python only.
+
+## What the comparison showed (2026-09-11)
+
+**The averaged mode converges at one step per period.** Measured against itself
+at 30 steps per period on an 11-cells-per-wavelength mesh:
+
+| helical, steps per period, at 1 wavelength/cell | 1 | 2 | 4 |
+| --- | --- | --- | --- |
+| envelope L2 | 7.8755e-3 | 7.8748e-3 | 7.8750e-3 |
+| runtime | 1.5 s | 1.9 s | 2.8 s |
+
+| helical, wavelengths per cell, at 1 step/period | 1 | 2 | 4 |
+| --- | --- | --- | --- |
+| envelope L2 | 7.9e-3 | 1.1e-2 | 2.4e-2 |
+| power / fine averaged | 0.9979 | 0.9978 | 0.9980 |
+
+The step changes the answer by ~1e-6, so one per period is already converged,
+and at 1.5 s that is 9.3x faster than the unaveraged solver on the deck's own
+settings (13.8 s). What is left, 0.2%, is the cell size.
+
+Planepole is step-insensitive in the same way, which matters because it is the
+polarisation carrying the residual discussed below. At 1 wavelength per cell,
+1 and 2 steps per period agree with each other to ~3e-7 relative, sit at the
+same 0.99779 of the fine averaged run, and leave the same gap to the converged
+unaveraged run - 0.9581 at 56 periods either way. One step per period runs in
+1.57 s against 13.9 s unaveraged. So the step is not a candidate explanation for
+that residual.
+
+Coarser cells hold their power to 0.25%, but **this deck cannot really
+discriminate them**: seeded, narrow band and flat top, so the envelope is
+nearly uniform along z2. The envelope error does triple between 1 and 4
+wavelengths per cell. Treat 1-2 wavelengths per cell as what is demonstrated
+here. A case with real longitudinal structure - SASE, sharp current gradients,
+a short bunch - will be far more sensitive, and 4 wavelengths per cell also caps
+the representable bandwidth at roughly +/-12% of the resonant frequency.
+
+**The unaveraged solver's default mesh is the less accurate of the two.**
+Helical, power at 60 periods, averaged (2 steps/period, 1 wavelength/cell;
+1 step/period reproduces these) over unaveraged:
+
+| unaveraged nodesPerLambdar / stepsPerPeriod | runtime | P_avg / P_unavg | envelope L2 |
+| --- | --- | --- | --- |
+| 12 / 30 | 13.8 s | 1.086 | 0.28 |
+| 24 / 60 | 26.4 s | 1.013 | 0.13 |
+| 48 / 120 | 53.9 s | 0.997 | 0.064 |
+| 96 / 240 | 110 s | 0.994 | 0.034 |
+
+The unaveraged result converges at second order in the mesh, towards a limit
+0.7% above the averaged one. At nodesPerLambdar = 12 it is ~9% low: linear
+deposition and linear interpolation each attenuate a carrier sampled at 11
+cells per wavelength by sinc^2(pi/11), so the coupling is ~5% weak. The step
+scans in `benchmark/convergence` could not see this - they held the mesh fixed
+and measured against a finer step on the same mesh. The averaged mode stores a
+smooth envelope, so it has no such loss.
+
+Every unaveraged run here scales the step with the mesh, holding 0.4 cells
+crossed per step, so in principle those sequences could be measuring step error
+rather than mesh error. They are not. Halving the step at fixed mesh, for
+planepole, changes the power by 4e-6 at nodesPerLambdar = 48 (120 to 240 steps
+per period) and by under 1e-6 at 96 (240 to 480), while refining the mesh at
+fixed cells per step moves it by 0.45% from 48 to 96. So the sequences are
+mesh-limited, and the averaged-to-unaveraged ratios below are unchanged when
+measured against the 480-step run.
+
+That is not in conflict with the ~1e-3 error at 0.4 cells per step reported in
+`benchmark/convergence`: that figure is the L2 error of the complex field
+against a same-mesh, finer-step reference, which is a different measure from
+mid-band power at a fixed distance.
+
+**What is left is the model.** The remaining helical 0.63% is the term the
+averaged mode drops: the radiation-driven transverse momentum
+(`eta p2 A / kappa^2` in `dppdz`), whose cross term with the quiver moves p2
+and so the phase. With that term zeroed in the unaveraged solver the two agree
+to ~0.07%.
+
+Planepole, power at 56 periods:
+
+| unaveraged nodesPerLambdar | 12 | 24 | 48 | 96 | 48, A-term zeroed |
+| --- | --- | --- | --- | --- | --- |
+| P_avg / P_unavg | 1.065 | 0.981 | 0.962 | 0.958 | 0.968 |
+
+Those are *total* power, which for a planar undulator is not a like-for-like
+comparison: the unaveraged run radiates at the odd harmonics, and the averaged
+mode carries one band, at the fundamental. Decomposing the final field of the
+n96 run band by band:
+
+| harmonic | 1 | 2 | 3 | 4 | 5 |
+| --- | --- | --- | --- | --- | --- |
+| % of total power, aw = 1.012 | 97.87 | 0.0024 | 1.72 | 0.0002 | 0.29 |
+| % of total power, aw = 0.5 | 99.87 | 0.0023 | 0.12 | 0.0003 | 0.002 |
+
+Odd harmonics only, as expected on axis in 1D; the even ones sit at leakage
+level. That also rules out a quiet-start artifact: 4 macroparticles per
+wavelength bunch the beam perfectly at the 4th harmonic, but the 4th does not
+couple and no power appears there. Helical shows no harmonic content at any
+mesh, which is why its total- and fundamental-power comparisons agree.
+
+Comparing the fundamental band alone, at n96, final dump:
+
+| | gap | A-term share | remainder | 3rd + 5th harmonic |
+| --- | --- | --- | --- | --- |
+| helical, aw = 1.012 | -0.63% | 0.56% | ~-0.07% | 0.00% |
+| planepole, aw = 1.012 | -1.67% | 0.60% | -1.07% | 2.01% |
+| planepole, aw = 0.5 | -1.46% | 0.52% | -0.95% | 0.12% |
+
+Helical is then fully accounted for by the dropped A-term. Planepole keeps ~1%
+that helical does not, and that remainder is flat in aw while the harmonic
+content changes by 17x between the two rows. So it is not harmonic emission
+being counted on one side of the comparison only, and probably not back-action
+from the harmonic fields either, since the harmonic field amplitude falls ~4x
+at aw = 0.5 and the remainder does not move. (The A-term share is also roughly
+aw-independent, ~0.55%, not the (1 + aw^2/2)/aw^2 scaling one might guess.)
+
+Two caveats on that reasoning. The averaged model omits the harmonics' drive on
+the electron energy equation, not only their emission, and there is no clean way
+to test that until the mode can carry more than one band - an additional
+envelope mesh for the 3rd harmonic, another for the 5th, and so on
+(UKFELs/Puffin#129). And the
+measure itself is still mesh-drifting: the planar remainder is 0.68% at n48 and
+1.07% at n96, with helical drifting by a similar 0.36 percentage points, so
+these are limits approached rather than converged values.
+
+The leading candidate for the remaining ~1% is planar-specific and O(rho). The
+planar source has a counter-rotating component at the carrier wavenumber that
+oscillates at twice the undulator phase; it drives a field ripple of relative
+size ~rho which beats back against the quiver in the energy equation, leaving a
+slow term. A helical source has no such component - its projection onto the
+carrier is purely slow. That predicts the remainder scales linearly with rho,
+halving at rho = 0.0025, which is the next diagnostic (UKFELs/Puffin#130).

--- a/benchmark/averaged/beam_file.in
+++ b/benchmark/averaged/beam_file.in
@@ -1,0 +1,21 @@
+&NBLIST
+nbeams = 1
+dtype = 'simple'
+/
+
+&BLIST
+sSigmaE = 0.084, 0.084, 1E8, 1.0, 1.0, 0.001
+sLenE = 1E-6, 1E-6, 50.0, 1E-6, 1E-6, 0.006
+emitx = 1.0
+emity = 1.0
+Ipk = 400
+bcenter = 0.0
+gammaf = 1.0
+iMPsZ2PerWave = 4
+TrLdMeth = 2
+nseqparts = 19
+qRndEj_G = .true.
+sSigEj_G = 0.1
+qFixCharge = .false.
+qMatched_A = .true.
+/

--- a/benchmark/averaged/compare.py
+++ b/benchmark/averaged/compare.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Compare a period-averaged Puffin run against an unaveraged one (1D).
+
+Usage: python3 compare.py <plain_dir> <avg_dir> <rho> [<undtype>]
+
+The unaveraged field A_perp is demodulated onto the averaged envelope's
+normalisation (see puffin/lib/undulator/averaging.f90):
+A+ = <A_perp exp(+i z2/2rho)>, averaged over exactly one resonant wavelength,
+and Atilde = sqrt(fp)/u- * A+.  That is compared node by node with the
+averaged run's stored envelope.  Power vs z is compared through the integrated
+files, as the mean of /power over the middle 30% of the mesh (the flat top);
+in the unaveraged planar case |A|^2 ripples at 2k_r, which that mean removes.
+
+Pure standard library: fields are pulled out with `h5dump -b LE`.
+"""
+
+import array
+import cmath
+import math
+import os
+import re
+import subprocess
+import sys
+
+
+def read_ds(path, ds):
+    binpath = path + "." + ds.strip("/").replace(" ", "_") + ".bin"
+    subprocess.run(["h5dump", "-d", ds, "-b", "LE", "-o", binpath, path],
+                   check=True, stdout=subprocess.DEVNULL)
+    vals = array.array("d")
+    with open(binpath, "rb") as fh:
+        vals.frombytes(fh.read())
+    os.remove(binpath)
+    return list(vals)
+
+
+def attr(path, name):
+    out = subprocess.run(["h5dump", "-A", path], check=True,
+                         stdout=subprocess.PIPE).stdout.decode()
+    m = re.search(r'ATTRIBUTE "%s" \{.*?\(0\): ([^\s]+)' % name, out, re.S)
+    return float(m.group(1))
+
+
+def last_index(d, stem):
+    ks = [int(re.search(r"_%s_(\d+)\.h5" % stem, f).group(1))
+          for f in os.listdir(d) if re.search(r"_%s_\d+\.h5$" % stem, f)]
+    return sorted(ks)
+
+
+def field(d, k):
+    p = os.path.join(d, "run_aperp_%d.h5" % k)
+    vals = read_ds(p, "/aperp")
+    n = len(vals) // 2
+    dz2 = attr(p, "vsUpperBounds") / int(attr(p, "vsNumCells"))
+    return [complex(vals[i], vals[n + i]) for i in range(n)], dz2, attr(p, "zbarTotal")
+
+
+def pol(undtype):
+    """sqrt(fp)/u-, taking the exp(-i z2/2rho) component to the stored envelope."""
+    cx, cy = {"helical": (1.0, 1.0), "planepole": (0.0, 1.0)}[undtype]
+    um, fp = 0.5 * (cy + cx), 0.5 * (cx * cx + cy * cy)
+    return math.sqrt(fp) / um
+
+
+def demod(A, dz2, rho, nper, fac):
+    """Envelope of the exp(-i z2/2rho) component, trapezoid over one wavelength.
+
+    The window must span exactly one wavelength (nper cells), or the 2k term
+    of a linearly polarised field does not cancel.
+    """
+    env = [fac * a * cmath.exp(1j * i * dz2 / (2 * rho)) for i, a in enumerate(A)]
+    h = nper // 2
+    out = []
+    for c in range(len(env)):
+        lo, hi = c - h, c - h + nper
+        if lo < 0 or hi >= len(env):
+            out.append(None)
+            continue
+        s = sum(env[lo:hi + 1]) - 0.5 * (env[lo] + env[hi])
+        out.append(s / (hi - lo))
+    return out
+
+
+def mid_power(d, k):
+    p = read_ds(os.path.join(d, "run_integrated_%d.h5" % k), "/power")
+    lo, hi = int(0.35 * len(p)), int(0.65 * len(p))
+    return sum(p[lo:hi]) / (hi - lo)
+
+
+def metrics(plain, avg, rho, undtype):
+    """(envelope rel L2 difference, rows, power table) for avg against plain."""
+    lamr = 4 * math.pi * rho
+    Ap, dzp, _ = field(plain, last_index(plain, "aperp")[-1])
+    Aa, dza, _ = field(avg, last_index(avg, "aperp")[-1])
+    env = demod(Ap, dzp, rho, int(round(lamr / dzp)), pol(undtype))
+
+    num = den = 0.0
+    rows = []
+    for j, a in enumerate(Aa):
+        i = int(round(j * dza / dzp))
+        if i >= len(env) or env[i] is None:
+            continue
+        e = env[i]
+        num += abs(a - e) ** 2
+        den += abs(e) ** 2
+        rows.append((j * dza, abs(e) ** 2, abs(a) ** 2, cmath.phase(e), cmath.phase(a)))
+
+    ks = sorted(set(last_index(plain, "integrated")) & set(last_index(avg, "integrated")))
+    power = [(k, mid_power(plain, k), mid_power(avg, k))
+             for k in ks[:: max(1, len(ks) // 15)] + [ks[-1]]]
+    return math.sqrt(num / den), rows, power
+
+
+def main():
+    plain, avg, rho = sys.argv[1], sys.argv[2], float(sys.argv[3])
+    undtype = sys.argv[4] if len(sys.argv) > 4 else "helical"
+
+    l2, rows, power = metrics(plain, avg, rho, undtype)
+    print("envelope rel L2 difference (avg vs demodulated plain): %.4e" % l2)
+
+    print("   z2      |A|^2 plain   |A|^2 avg    phase plain  phase avg")
+    for r in rows[:: max(1, len(rows) // 12)]:
+        print("  %6.2f  %11.4e  %11.4e  %9.4f  %9.4f" % r)
+
+    print()
+    print("  write   P plain      P avg      avg/plain")
+    for k, pp, pa in power:
+        print("  %4d  %11.4e  %11.4e  %8.4f" % (k, pp, pa, pa / pp if pp else float("nan")))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/averaged/compare_avg.py
+++ b/benchmark/averaged/compare_avg.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Compare averaged-mode runs against an averaged reference (1D).
+
+Usage: python3 compare_avg.py <ref_dir> <dir> [<dir> ...]
+
+Both hold the envelope directly, so no demodulation: the reference envelope is
+sampled at each run's nodes (mesh spacings are integer multiples of each other
+here) and compared in relative L2; the mid-bunch power at the last common
+integrated write is compared as a ratio.
+"""
+
+import os
+import sys
+
+from compare import field, last_index, read_ds
+
+
+def mid_power(d, k):
+    p = read_ds(os.path.join(d, "run_integrated_%d.h5" % k), "/power")
+    lo, hi = int(0.35 * len(p)), int(0.65 * len(p))
+    return sum(p[lo:hi]) / (hi - lo)
+
+
+def main():
+    ref = sys.argv[1]
+    Ar, dzr, _ = field(ref, last_index(ref, "aperp")[-1])
+    kr = last_index(ref, "integrated")[-1]
+    pr = mid_power(ref, kr)
+    print("  %-18s %-9s %-12s %s" % ("run", "dz2/dzr", "env rel L2", "P/P_ref (last write)"))
+    for d in sys.argv[2:]:
+        A, dz, _ = field(d, last_index(d, "aperp")[-1])
+        m = dz / dzr
+        num = den = 0.0
+        for j, a in enumerate(A):
+            i = int(round(j * m))
+            if i >= len(Ar):
+                break
+            num += abs(a - Ar[i]) ** 2
+            den += abs(Ar[i]) ** 2
+        k = min(kr, last_index(d, "integrated")[-1])
+        print("  %-18s %-9.2f %-12.4e %.5f" % (d, m, (num / den) ** 0.5, mid_power(d, k) / pr))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/averaged/deck.in
+++ b/benchmark/averaged/deck.in
@@ -1,0 +1,47 @@
+! Averaged-vs-unaveraged comparison deck (see README.md).
+! Seeded, noise-free, single undulator, no lattice file, no undulator ends:
+! everything that could add run-to-run variance is off, so the only thing
+! that changes between runs is what run_compare.py sets: the solver mode,
+! mesh, step, undulator type and aw.
+
+&MDATA
+ qOneD                  = .true.
+ qFieldEvolve           = .true.
+ qElectronsEvolve       = .true.
+ qElectronFieldCoupling = .true.
+ qFocussing             = .false.
+ qDiffraction           = .false.
+ qFilter                = .true.
+ q_noise                = .false.
+ qUndEnds               = .false.
+ beam_file              = 'beam_file.in'
+ sElectronThreshold     = 0.05
+ iNumNodesX             = 1
+ iNumNodesY             = 1
+ nodesPerLambdar        = 12
+ sFModelLengthX         = 4.0
+ sFModelLengthY         = 4.0
+ sFModelLengthZ2        = 60.0
+ iRedNodesX             = 1
+ iRedNodesY             = 1
+ sFiltFrac              = 0.3
+ sDiffFrac              = 1.0
+ sBeta                  = 1.0
+ seed_file              = 'seed_file.in'
+ srho                   = 0.005
+ sux                    = 1.0
+ suy                    = 1.0
+ saw                    = 1.0121809
+ sgamma_r               = 456.40
+ lambda_w               = 0.0275
+ Dfact                  = 0.0
+ zundType               = 'planepole'
+ taper                  = 0.0
+ lattFile               = ''
+ stepsPerPeriod         = 30
+ nPeriods               = 60
+ sZ0                    = 0.0
+ iWriteNthSteps         = 1000000
+ iWriteIntNthSteps      = 1000000
+ sPEOut                 = 0.0
+ /

--- a/benchmark/averaged/run_compare.py
+++ b/benchmark/averaged/run_compare.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Run the averaged and unaveraged solvers on the same 1D deck and compare.
+
+Usage:
+  python3 run_compare.py <helical|planepole> [--aw AW]
+                         [--plain NODES:STEPS ...] [--avg CELLS:STEPS ...]
+
+  --plain NODES:STEPS   unaveraged run, nodesPerLambdar = NODES,
+                        stepsPerPeriod = STEPS     [default 12:30 24:60 48:120]
+  --avg CELLS:STEPS     averaged run, lambdarPerCell = CELLS,
+                        stepsPerPeriod = STEPS     [default 1:2]
+
+The first --avg run is compared against every --plain run: envelope relative L2
+difference, and mid-bunch power ratio at the last write.  Keep NODES/STEPS at
+0.4 cells per step or finer for the unaveraged runs, or they are measuring
+their own step error (see benchmark/convergence).  Needs mpirun and h5dump;
+standard library Python only.  PUFFIN overrides the executable path.
+"""
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+
+from compare import metrics
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+PUFFIN = os.environ.get("PUFFIN",
+                        os.path.join(HERE, "..", "..", "build", "puffin", "puffin"))
+RHO = 0.005
+
+
+def sub(text, name, value):
+    return re.sub(r"(?m)^(\s*%s\s*=\s*)[^\n]*$" % name, r"\g<1>%s" % value, text)
+
+
+def run(tag, und, aw, averaged, mesh, steps):
+    workdir = os.path.join(HERE, "run_%s" % tag)
+    shutil.rmtree(workdir, ignore_errors=True)
+    os.makedirs(workdir)
+    shutil.copy(os.path.join(HERE, "beam_file.in"), workdir)
+
+    with open(os.path.join(HERE, "seed_file.in")) as fh:
+        seed = fh.read()
+    if und == "helical":            # the resonant helicity, circularly polarised
+        seed = sub(seed, "sA0_Y", "0.01")
+    with open(os.path.join(workdir, "seed_file.in"), "w") as fh:
+        fh.write(seed)
+
+    with open(os.path.join(HERE, "deck.in")) as fh:
+        deck = fh.read()
+    deck = sub(deck, "zundType", "'%s'" % und)
+    deck = sub(deck, "saw", aw)
+    deck = sub(deck, "stepsPerPeriod", steps)
+    deck = sub(deck, "iWriteIntNthSteps", steps)     # one integrated write per period
+    if averaged:
+        mode = " qAveraged = .true.\n lambdarPerCell = %s\n" % mesh
+    else:
+        deck = sub(deck, "nodesPerLambdar", mesh)
+        mode = " qAveraged = .false.\n"
+    deck = deck.replace("&MDATA\n", "&MDATA\n" + mode)
+    with open(os.path.join(workdir, "run.in"), "w") as fh:
+        fh.write(deck)
+
+    env = dict(os.environ, OMP_NUM_THREADS="1")
+    proc = subprocess.run(["mpirun", "-np", "1", PUFFIN, "run.in"], cwd=workdir, env=env,
+                          stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    out = proc.stdout.decode(errors="replace")
+    if proc.returncode != 0 or "Tried rearranging" in out:
+        sys.stderr.write(out[-2000:])
+        raise SystemExit("puffin failed for %s" % tag)
+    m = re.search(r"Finished undulator module in\s+([0-9.E+-]+)", out)
+    return workdir, float(m.group(1)) if m else float("nan")
+
+
+def main():
+    args = sys.argv[1:]
+    und, aw = args.pop(0), "1.0121809"
+    plains, avgs, which = [], [], None
+    while args:
+        a = args.pop(0)
+        if a == "--aw":
+            aw = args.pop(0)
+        elif a in ("--plain", "--avg"):
+            which = plains if a == "--plain" else avgs
+        else:
+            which.append(tuple(a.split(":")))
+    plains = plains or [("12", "30"), ("24", "60"), ("48", "120")]
+    avgs = avgs or [("1", "2")]
+
+    avg_runs = []
+    for cells, steps in avgs:
+        wd, secs = run("%s_avg_c%s_s%s" % (und, cells, steps), und, aw, True, cells, steps)
+        avg_runs.append((cells, steps, wd, secs))
+        print("  averaged   lambdarPerCell=%-5s steps=%-4s %7.1f s" % (cells, steps, secs),
+              flush=True)
+
+    ref_avg = avg_runs[0][2]
+    print()
+    print("  %-10s %-16s %-9s %-12s %s" % ("und", "unaveraged", "runtime", "env rel L2",
+                                          "P_avg/P_unavg (last write)"))
+    for nodes, steps in plains:
+        wd, secs = run("%s_plain_n%s_s%s" % (und, nodes, steps), und, aw, False, nodes, steps)
+        l2, _, power = metrics(wd, ref_avg, RHO, und)
+        k, pp, pa = power[-1]
+        print("  %-10s n=%-4s s=%-8s %7.1f s %-12.4e %.4f" % (und, nodes, steps, secs, l2, pa / pp),
+              flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/averaged/seed_file.in
+++ b/benchmark/averaged/seed_file.in
@@ -1,0 +1,14 @@
+&NSLIST
+nseeds = 1
+/
+
+&SLIST
+freqf = 1.0
+sA0_X = 0.01
+sA0_Y = 0.0
+sSigmaF = 1E8, 1E8, 1E8
+qFlatTop = .true.
+meanZ2 = 0.0
+qRndFj_G = .false.
+sSigFj_G = 0.1
+/

--- a/doc/manual.tex
+++ b/doc/manual.tex
@@ -803,6 +803,29 @@ The formalism for including a variation in the magnetic undulator field, so that
 
 
 
+\subsection{Period-Averaged Mode}
+
+\label{puff-avg}
+
+With {\bf qAveraged} set, Puffin solves a period-averaged form of the equations above. Both fast phases carry the same $1/2\rho$ in the scaled variables: the undulator phase is $\bar{z}/2\rho$ and the radiation phase $\bar{z}_2/2\rho$, so the ponderomotive phase of electron $j$ is
+\begin{align}
+\theta_j = \frac{\bar{z} - \bar{z}_{2j}}{2\rho}, \qquad \frac{d\theta_j}{d\bar{z}} = \frac{1 - p_{2j}}{2\rho},
+\end{align}
+slow exactly at Puffin's resonance condition $p_2 = 1$. With the on-axis undulator field $b_x = u_x \cos(\bar{z}/2\rho)$, $b_y = u_y \sin(\bar{z}/2\rho)$, the quiver is $\bar{p}_{\bot w} = -\alpha[u_+ e^{i\bar{z}/2\rho} + u_- e^{-i\bar{z}/2\rho}]$ with $u_\mp = (u_y \pm u_x)/2$, and the resonant component of the field is the one at $e^{-i\bar{z}_2/2\rho}$. The field is written in terms of a slowly varying envelope $\tilde{A}$,
+\begin{align}
+A_\bot = \frac{u_-}{\sqrt{f_p}} \tilde{A}\, e^{-i\bar{z}_2/2\rho} + \frac{u_+}{\sqrt{f_p}} \tilde{A}^*\, e^{+i\bar{z}_2/2\rho}, \qquad f_p = \frac{u_x^2 + u_y^2}{2},
+\end{align}
+which is exact for a helical ($u_+ = 0$) or linearly polarised ($|u_+| = |u_-|$) undulator, and normalised so that $|\tilde{A}|^2$ is the period average of $|A_\bot|^2$. The transverse momentum $\bar{p}_\bot$ holds only its slow part. Averaging over an undulator period, the coupling is carried by an effective resonant momentum
+\begin{align}
+\tilde{p}_j = -\alpha \sqrt{f_p}\, JJ_j\, e^{-i\theta_j}, \qquad JJ_j = J_0(\xi_j) - \frac{u_+}{u_-} J_1(\xi_j), \qquad \xi_j = \frac{(1 + \eta p_{2j})^3 \bar{a}_u^2 \alpha^2 (u_y^2 - u_x^2)}{8 \eta \gamma_r^2 \Gamma_j^2},
+\end{align}
+where $\xi_j$ is the phase amplitude of the figure-of-eight excursion in $\bar{z}_2$ that a planar undulator imposes through the $2\bar{z}/2\rho$ ripple in $|\bar{p}_{\bot w}|^2$. $\tilde{p}_j$ replaces $\bar{p}_{\bot j}$ in both the field source and the energy equation,
+\begin{align}
+\frac{\partial \tilde{A}}{\partial \bar{z}} &= \frac{1}{\bar{n}_p}\sum_{j} \frac{\tilde{p}_j}{\Gamma_j} (1+\eta p_{2j}) \delta(\bar{z}_2 - \bar{z}_{2j}) \quad \text{(1D)}, \\
+\frac{d \Gamma_{j}}{d \bar{z}} &= - \rho \frac{(1 + \eta p_{2j})}{\Gamma_j} (\tilde{p}_j \tilde{A}^*_j + c.c.),
+\end{align}
+which is what makes the averaged system conserve beam plus field energy exactly. $p_{2j}$ is evaluated with $|\bar{p}_\bot|^2 + \alpha^2 f_p$ in place of $|\bar{p}_\bot|^2$ - the $\bar{a}_u \rightarrow \bar{a}_{u,rms}$ substitution - and in 1D the slow transverse momentum is constant. The radiation-driven quiver, the $\eta p_2 A_\bot / \kappa^2$ term of equation \eqref{pperpeqn2}, is dropped; its slow effect on $p_2$ is $O(\rho)$ relative to the pendulum dynamics.
+
 \subsection{Full Magnetic Undulator Field Analytic Description}
 
 The analytic description of the undulator fields are based on those discussed in \cite{scharlemann1}, which in the scaled notation here are:-
@@ -990,7 +1013,11 @@ Length of the periodic mesh, expressed as the number of reference resonant wavel
 
 {\bf nodesPerLambdar}
 
-Number of nodes in the field mesh to use in the longitudinal dimension per reference resonant wavelength. The reference resonant wavelength is defined from the reference energy {\bf sgamma\_r}, the undulator period {\bf lambda\_w} and the base or reference undulator parameter {\bf saw} in the usual way. [17]
+Number of nodes in the field mesh to use in the longitudinal dimension per reference resonant wavelength. The reference resonant wavelength is defined from the reference energy {\bf sgamma\_r}, the undulator period {\bf lambda\_w} and the base or reference undulator parameter {\bf saw} in the usual way. Ignored in the period-averaged mode ({\bf qAveraged}), which uses {\bf lambdarPerCell} instead. [17]
+
+{\bf lambdarPerCell}
+
+Longitudinal field mesh spacing in reference resonant wavelengths, used in place of {\bf nodesPerLambdar} in the period-averaged mode ({\bf qAveraged} $=$ .true.), where the mesh holds an envelope and need not resolve the resonant wavelength. The envelope bandwidth it can represent is roughly $\pm 1/(2\times${\bf lambdarPerCell}$)$ of the resonant frequency. Values of $1$--$2$ are typical. Ignored when {\bf qAveraged} is .false. [1.0]
 
 {\bf sFModelLengthZ2}
 
@@ -1126,6 +1153,10 @@ Logical turning on/off the input of scaled units into Puffin. If {\bf .true.}, i
 {\bf qFilter}
 
 Logical turning on/off the filtering of low frequency content during the siffraction step. The high-pass filter cut-off is defined by {\bf sFiltFrac}. If true, the low frequency content is set $=0$. If false, the low frequency content is not manipulated/diffracted. [.true.]
+
+{\bf qAveraged}
+
+Logical turning on/off the period-averaged (SVEA) solver mode, described in Section~\ref{puff-avg}. When {\bf .true.}, the field mesh holds the slowly varying envelope of the radiation about the resonant carrier rather than the resolved field, and the electron equations are averaged over an undulator period, with the quiver carried analytically. The mesh no longer has to resolve the resonant wavelength, and is set by {\bf lambdarPerCell}; the step no longer has to resolve the undulator period either, and {\bf stepsPerPeriod} $=1$ or $2$ is usually enough. It is an opt-in alternative to the unaveraged solver for regimes where averaging is valid: it discards coherent spontaneous emission from sharp current gradients, bandwidth beyond the envelope mesh's roughly $\pm 1/(2\times${\bf lambdarPerCell}$)$ of the resonant frequency, harmonics, and electrons far from resonance, for which the ponderomotive phase is no longer slow. Two-colour and strongly tapered cases fall in that last class. Currently 1D only, and for helical or linearly polarised undulators; the undulator ends, if modelled, only ramp the coupling. [.false.]
 
 {\bf ioutinfo}
 

--- a/puffin/lib/adapter_globals.f90
+++ b/puffin/lib/adapter_globals.f90
@@ -35,7 +35,7 @@ use Globals, only: NX_G, NBX_G, NY_G, NBY_G, NZ2_G, NBZ2_G, nspinDX, nspinDY, sL
   totUndLineLength, iWriteNthSteps, iIntWriteNthSteps, cmd_call_G, zFileName_G, zBFile_G, &
   zSFile_G, ioutInfo_G, frecvs, fdispls, qElectronsEvolve_G, qFieldEvolve_G, &
   qElectronFieldCoupling_G, qDiffraction_G, qFocussing_G, qFilter, qDump_G, qSeparateStepFiles_G, &
-  qMod_G, qResume, qWrite, qOneD_G, qscaled_G, qInitWrLat_G, qDumpEnd_G
+  qMod_G, qResume, qWrite, qOneD_G, qAveraged_G, qscaled_G, qInitWrLat_G, qDumpEnd_G
 
 implicit none (type, external)
 
@@ -780,6 +780,9 @@ subroutine PopulateSimulationFlagsFromGlobals(flags)
     flags%one_dimensional = qOneD_G
     flags%using_modules = qMod_G
 
+    ! Solver mode
+    flags%period_averaged = qAveraged_G
+
     ! Mesh properties
     flags%fixed_mesh = qFMesh_G
     flags%fixed_charge = qFixCharge_G
@@ -861,6 +864,7 @@ subroutine UpdateGlobalsFromSimulationFlags(flags)
     ! Simulation type
     qOneD_G = flags%one_dimensional
     qMod_G = flags%using_modules
+    qAveraged_G = flags%period_averaged
 
     ! Mesh properties
     qFMesh_G = flags%fixed_mesh

--- a/puffin/lib/deriv_globals.f90
+++ b/puffin/lib/deriv_globals.f90
@@ -33,12 +33,13 @@ public :: ata_G, c, chic_disp, chic_slip, chic_zbar, cmd_call_G, dadz_w, delmz, 
            outnodey_G, pi, procelectrons_G, q_e, qDiffraction_G, qDump_G, qDumpEnd_G, &
            qElectronFieldCoupling_G, qElectronsEvolve_G, qEquiXY_G, qFieldEvolve_G, qFilter, &
            qFixCharge_G, qFMesh_G, qFocussing_G, qhdf5_G, qInitWrLat_G, qMatchS_G, qMod_G, &
-           qOneD_G, qResume, qResume_G, qRndEj_G, qRndFj_G, qscaled_G, qsdds_G, &
+           qAveraged_G, qOneD_G, qResume, qResume_G, qRndEj_G, qRndFj_G, qscaled_G, qsdds_G, &
            qSeparateStepFiles_G, &
            quad_fx, quad_fy, qUndEnds_G, qUseEmit_G, qWrite, s_chi_bar_G, s_Normalised_chi_G, &
            sBeta_G, seedend, sElGam_G, sElPX_G, sElPY_G, sElX_G, sElY_G, sElZ2_G, sfilt, &
            sFocusfactor_G, sFocusfactor_save_G, sKBeta_G, sKBetaX_G, sKBetaXSF_G, sKBetaY_G, &
-           sKBetaYSF_G, sLengthOfElmX_G, sLengthOfElmY_G, sLengthOfElmZ2_G, sMNum_G, sperwaves_G, &
+           sKBetaYSF_G, sLambdarPerCell_G, sLengthOfElmX_G, sLengthOfElmY_G, sLengthOfElmZ2_G, &
+           sMNum_G, sperwaves_G, &
            sRedistLen_G, sSigEj_G, sSigFj_G, sStep, sStepSize, start_step, sZFE, sZFS, sZlSt_G, &
            tapers, tArrayA, tArrayE, tArrayZ, time1, time2, tInitData_G, totUndLineLength, &
            TrLdMeth_G, ux_arr, uy_arr, WP, x_ax_G, y_ax_G, zBFile_G, zFileName_G, zMod, zSFile_G, &
@@ -389,6 +390,15 @@ logical   ::  qFocussing_G       ! Provide Focusing for electron beam?
 logical   ::  qFilter            ! High pass filter for radiation field
                                  ! during diffraction? If not, the frequencies
                                  ! below the cutoff are simply not diffracted.
+
+
+logical   ::  qAveraged_G        ! Period-averaged (SVEA) mode? The field
+                                 ! arrays hold the envelope about the resonant
+                                 ! carrier. See averaging.f90. Off by default.
+
+real(kind=wp) :: sLambdarPerCell_G  ! z2 mesh spacing in resonant wavelengths,
+                                    ! averaged mode only (replaces
+                                    ! nodesPerLambdar there)
 
 
 logical   ::  qDump_G            ! Dump data in case of crash?

--- a/puffin/lib/global_types.f90
+++ b/puffin/lib/global_types.f90
@@ -281,6 +281,11 @@ type :: tSimulationFlags
     logical :: one_dimensional               ! qOneD_G
     logical :: using_modules                 ! qMod_G
 
+    ! Solver mode
+    logical :: period_averaged               ! qAveraged_G - field held as a
+                                             ! slowly varying envelope, quiver
+                                             ! averaged out (see averaging.f90)
+
     ! Mesh properties
     logical :: fixed_mesh                    ! qFMesh_G
     logical :: fixed_charge                  ! qFixCharge_G

--- a/puffin/lib/interaction/rhs.f90
+++ b/puffin/lib/interaction/rhs.f90
@@ -22,7 +22,8 @@ use Equations, only: dppdz_r_f, dppdz_i_f, dgamdz_f, dxdz_f, dydz_f, dz2dz_f, al
 use wigglerVar, only: getalpha
 use FiElec1D, only: getinterps_1d, getffelecs_1d, getsource_1d
 use FiElec, only: getinterps_3d, getffelecs_3d, getsource_3d
-use gtop2, only: getp2
+use gtop2, only: getp2, getp2avg
+use averaging, only: tAvgCoupling, getAvgCoupling, getResonantMomentum
 use ParaField, only: fz2, tTransInfo_G
 use bfields, only: getbfields
 use GlobalTypes, only: tUndulator, tFELFrame, tSimulationContext
@@ -104,6 +105,14 @@ contains
 
   logical :: qOKL
 
+! Averaged mode only - see averaging.f90. sprRes, spiRes hold the resonant
+! momentum ptilde_j, which replaces spr, spi wherever the electrons couple to
+! the field. One array for both the source and the energy equation is what
+! keeps the averaged system energy-conserving.
+
+  real(kind=wp), allocatable :: sprRes(:), spiRes(:)
+  type(tAvgCoupling) :: cpl
+
 !     Begin
 
   qOK = .false.
@@ -138,6 +147,10 @@ contains
   call getAlpha(sZ, ctx%und)
   call adjUndPlace(sZ, ctx%und)
 
+  if (ctx%flags%period_averaged) then
+    call getAvgCoupling(sZ, ctx%und, ctx%frame, cpl)
+    allocate(sprRes(iNumberElectrons_G), spiRes(iNumberElectrons_G))
+  end if
 
 
 !$OMP PARALLEL
@@ -148,7 +161,14 @@ contains
 !     end do
 ! !$OMP END SIMD
 
-  call getP2(sp2, sgam, spr, spi, ctx%frame%eta, ctx%frame%gamma_ref, ctx%frame%aw)
+  if (ctx%flags%period_averaged) then
+    call getP2Avg(sp2, sgam, spr, spi, ctx%frame%eta, ctx%frame%gamma_ref, &
+                  ctx%frame%aw, cpl%pqSq)
+    call getResonantMomentum(sZ, sz2, sgam, sp2, ctx%frame%eta, ctx%frame%rho, cpl, &
+                             sprRes, spiRes)
+  else
+    call getP2(sp2, sgam, spr, spi, ctx%frame%eta, ctx%frame%gamma_ref, ctx%frame%aw)
+  end if
 
 
 
@@ -201,7 +221,11 @@ contains
     call getInterps_1D(sz2, ctx%flags)
     if (ctx%flags%parallel_arrays_ok) then
       call getFFelecs_1D(sAr, sAi)
-      call getSource_1D(sDADzr, sDADzi, spr, spi, sgam, ctx%frame%eta)
+      if (ctx%flags%period_averaged) then
+        call getSource_1D(sDADzr, sDADzi, sprRes, spiRes, sgam, ctx%frame%eta)
+      else
+        call getSource_1D(sDADzr, sDADzi, spr, spi, sgam, ctx%frame%eta)
+      end if
     end if
 
   else
@@ -209,7 +233,11 @@ contains
     call getInterps_3D(sx, sy, sz2, ctx%flags)
     if ((ctx%flags%parallel_arrays_ok) .and. (ctx%flags%inner_xy_ok)) then
       call getFFelecs_3D(sAr, sAi)
-      call getSource_3D(sDADzr, sDADzi, spr, spi, sgam, ctx%frame%eta)
+      if (ctx%flags%period_averaged) then
+        call getSource_3D(sDADzr, sDADzi, sprRes, spiRes, sgam, ctx%frame%eta)
+      else
+        call getSource_3D(sDADzr, sDADzi, spr, spi, sgam, ctx%frame%eta)
+      end if
     end if
 
   end if
@@ -233,8 +261,10 @@ contains
 
     if (qElectronsEvolve_G) then
 
-        call getBFields(sx, sy, sz, &
-                        bxu, byu, bzu, ctx%und, ctx%frame)
+        if (.not. ctx%flags%period_averaged) then
+          call getBFields(sx, sy, sz, &
+                          bxu, byu, bzu, ctx%und, ctx%frame)
+        end if
 
 !     z2
 
@@ -252,20 +282,42 @@ contains
                     sdy, ctx%frame)
 
 
+        if (ctx%flags%period_averaged) then
+
+!     Averaged mode: pperp holds only its slow part. The undulator quiver is
+!     carried analytically, and the radiation-driven quiver (the A term in
+!     dppdz) rotates against the carrier and averages out. What is left is
+!     focusing, which is zero in 1D - the only geometry averaged mode
+!     supports so far; setup rejects 3D.
+
+!$OMP WORKSHARE
+          sdpr = 0.0_wp
+          sdpi = 0.0_wp
+!$OMP END WORKSHARE
+
+!     Energy exchange with the envelope, through the same ptilde as the source
+
+          call dgamdz_f(sx, sy, sz2, sprRes, spiRes, sgam, &
+                        sdgam, ctx%frame)
+
+        else
+
 !     PX (Real pperp)
 
-        call dppdz_r_f(sx, sy, sz2, spr, spi, sgam, sZ, &
-                       sdpr, ctx%und, ctx%frame)
+          call dppdz_r_f(sx, sy, sz2, spr, spi, sgam, sZ, &
+                         sdpr, ctx%und, ctx%frame)
 
 !     -PY (Imaginary pperp)
 
-        call dppdz_i_f(sx, sy, sz2, spr, spi, sgam, sz, &
-                       sdpi, ctx%und, ctx%frame)
+          call dppdz_i_f(sx, sy, sz2, spr, spi, sgam, sz, &
+                         sdpi, ctx%und, ctx%frame)
 
 !     P2
 
-        call dgamdz_f(sx, sy, sz2, spr, spi, sgam, &
-                     sdgam, ctx%frame)
+          call dgamdz_f(sx, sy, sz2, spr, spi, sgam, &
+                       sdgam, ctx%frame)
+
+        end if
 
     end if
 

--- a/puffin/lib/io/read_base_input.f90
+++ b/puffin/lib/io/read_base_input.f90
@@ -26,7 +26,7 @@ use Globals, only: nspinDX, nspinDY, iRedNodesX_G, iRedNodesY_G, fieldMesh, sper
   iFieldSeedType_G, iSimpleSeed_G, iReadH5Field_G, TrLdMeth_G, sKBetaXSF_G, sKBetaYSF_G, &
   qUndEnds_G, qhdf5_G, sRedistLen_G, iRedistStp_G, tArrayA, tArrayZ, iWriteNthSteps, cmd_call_G, &
   zBFile_G, zSFile_G, ioutInfo_G, qDiffraction_G, qFilter, qResume, qWrite, qscaled_G, &
-  qInitWrLat_G, qDumpEnd_G
+  qInitWrLat_G, qDumpEnd_G, qAveraged_G, sLambdarPerCell_G
 use MASPin, only: nMPs4MASP_G
 use cwrites, only: qWrArray_G, getwrarray
 use randomGauss, only: setRandomSeed
@@ -268,10 +268,11 @@ subroutine read_in(zfilename, &
   logical :: qOneD, qFieldEvolve, qElectronsEvolve, &
              qElectronFieldCoupling, qFocussing, &
              qDiffraction, qDump, qUndEnds, qhdf5, qsdds, &
-             qscaled, qInitWrLat, qDumpEnd
+             qscaled, qInitWrLat, qDumpEnd, qAveraged
 
   integer(kind=ip) :: iNumNodesX, iNumNodesY, nodesPerLambdar
   real(kind=wp) :: sFModelLengthX, sFModelLengthY, sFModelLengthZ2
+  real(kind=wp) :: lambdarPerCell
 
   real(kind=wp) :: sKBetaXSF, sKBetaYSF
 
@@ -312,7 +313,7 @@ namelist /mdata/ qOneD, qFieldEvolve, qElectronsEvolve, &
                  qFMesh_G, sKBetaXSF, sKBetaYSF, sRedistLen, &
                  iRedistStp, qscaled, nspinDX, nspinDY, qInitWrLat, qDumpEnd, &
                  wr_file, qMeasure, DFact, iDumpNthSteps, speout, meshType, &
-                 sPerWaves, ioutInfo, iRandSeed
+                 sPerWaves, ioutInfo, iRandSeed, qAveraged, lambdarPerCell
 
 
 ! Begin subroutine:
@@ -332,6 +333,8 @@ namelist /mdata/ qOneD, qFieldEvolve, qElectronsEvolve, &
   qFocussing = .false.
   qDiffraction = .true.
   qFilter = .true.
+  qAveraged = .false.
+  lambdarPerCell = 1.0_wp
   q_noise = .true.
   qUndEnds = .false.
   qDump = .false.
@@ -423,6 +426,8 @@ namelist /mdata/ qOneD, qFieldEvolve, qElectronsEvolve, &
   qSwitches(iDump_CG) = qDump
 
   qUndEnds_G = qUndEnds
+  qAveraged_G = qAveraged
+  sLambdarPerCell_G = lambdarPerCell
   qhdf5_G = qhdf5
   qscaled_G = qscaled
   qInitWrLat_G = qInitWrLat

--- a/puffin/lib/parallel/para_field.f90
+++ b/puffin/lib/parallel/para_field.f90
@@ -19,7 +19,7 @@ use globals, only: NX_G, NY_G, NZ2_G, ntrnds_G, ntrndsi_G, nspinDX, nspinDY, sLe
 use ParallelSetUp, only: MPI_INT_HIGH, stopcode, gather1a, getgatharrs
 use puffin_mpiInfo, only: tProcInfo_G
 use puffin_fftwInfo, only: tTransInfo_G
-use gtop2, only: getp2
+use gtop2, only: getp2, getp2avg
 use GlobalTypes, only: tSimulationFlags, tFELFrame
 use mpi, only: MPI_ALLGATHER, mpi_allreduce, mpi_alltoallv, mpi_barrier, MPI_Bcast, &
   mpi_double_precision, MPI_IN_PLACE, mpi_integer, MPI_ISSEND, mpi_max, mpi_min, MPI_RECV, &
@@ -94,7 +94,7 @@ logical :: qStart_new
 contains
 
 
-        subroutine getLocalFieldIndices(sdz, flags, frame)
+        subroutine getLocalFieldIndices(sdz, flags, frame, pqSq)
 
     implicit none (type, external)
 
@@ -114,6 +114,7 @@ contains
     real(kind=wp), intent(in) :: sdz
     type(tSimulationFlags), intent(inout) :: flags
     type(tFELFrame), intent(in) :: frame
+    real(kind=wp), intent(in), optional :: pqSq   ! passed in averaged mode only - see calcBuff
 
     real(kind=wp), allocatable :: fr_rfield_old(:), &
                                   fr_ifield_old(:), &
@@ -240,7 +241,14 @@ contains
 
   if (qUnique) call rearrElecs()   ! Rearrange electrons
 
-  call calcBuff(4 * pi * frame%rho * sdz, frame%eta, frame%gamma_ref, frame%aw)  ! Calculate buffers
+! Branch on the argument, not on flags%period_averaged: init calls this
+! before the flags are populated.
+
+  if (present(pqSq)) then
+    call calcBuff(4 * pi * frame%rho * sdz, frame%eta, frame%gamma_ref, frame%aw, pqSq)  ! Calculate buffers
+  else
+    call calcBuff(4 * pi * frame%rho * sdz, frame%eta, frame%gamma_ref, frame%aw)  ! Calculate buffers
+  end if
 
   call getFrBk()  ! Get surrounding nodes
 
@@ -1703,7 +1711,7 @@ contains
 
 
 
-  subroutine calcBuff(dz, sEta, sGammaR, sAw)
+  subroutine calcBuff(dz, sEta, sGammaR, sAw, pqSq)
 
 ! Subroutine to setup the 'buffer' region
 ! at the end of the parallel field section
@@ -1717,6 +1725,14 @@ contains
 ! dz through the undulator.
 
     real(kind=wp), intent(in) :: dz, sEta, sGammaR, sAw
+
+! Present only in the averaged mode: the period average of the undulator
+! quiver |pperp|^2.  There sElPX_G/sElPY_G hold only the slow part of pperp,
+! and would otherwise predict the drift-space p2 - roughly half the
+! in-undulator value - and so too small a buffer.  Absent, this routine is
+! exactly as it was, so the unaveraged path is untouched.
+
+    real(kind=wp), intent(in), optional :: pqSq
     real(kind=wp), allocatable :: sp2(:)
 
     real(kind=wp) :: bz2_len
@@ -1740,7 +1756,11 @@ contains
 
       allocate(sp2(iNumberElectrons_G))
 
-      call getP2(sp2, sElGam_G, sElPX_G, sElPY_G, sEta, sGammaR, sAw)
+      if (present(pqSq)) then
+        call getP2Avg(sp2, sElGam_G, sElPX_G, sElPY_G, sEta, sGammaR, sAw, pqSq)
+      else
+        call getP2(sp2, sElGam_G, sElPX_G, sElPY_G, sEta, sGammaR, sAw)
+      end if
 
       bz2_len = dz  ! distance in zbar until next rearrangement
       ! predicted length in z2 needed needed in buffer for beam
@@ -1762,7 +1782,23 @@ contains
 !    bz2 = ez2 + nint(4 * 4 * pi * sRho_G / sLengthOfElmZ2_G)
 !    Boundary only 4 lambda_r long - so can only go ~ 3 periods
 
-    bz2 = nint(bz2_len / sLengthOfElmZ2_G)  ! node index of final node in boundary
+!   Node index of the final node in the boundary. The furthest particle
+!   interpolates onto nodes floor(z2/dz2) + 1 and + 2, and getInterps_* need
+!   its lower node to lie below bz2, so bz2 must reach floor(z2/dz2) + 2.
+!   Rounding to the nearest node leaves the buffer up to 1.5 cells short.
+!   That is harmless while the slippage over a redistribution interval spans
+!   many cells, as on a mesh resolving the carrier, but on the coarse envelope
+!   mesh of the averaged mode it is a fraction of a cell and the
+!   rearrangement fails outright - so the averaged mode uses the exact bound.
+!   The unaveraged path keeps nint: changing the buffer there changes the
+!   parallel layout, and with it the summation order, so the e2e goldens
+!   would no longer match at 1e-10.
+
+    if (present(pqSq)) then
+      bz2 = floor(bz2_len / sLengthOfElmZ2_G, kind=ip) + 2_ip
+    else
+      bz2 = nint(bz2_len / sLengthOfElmZ2_G)
+    end if
 
     if (fieldMesh == iPeriodic) then
 

--- a/puffin/lib/setup/checks.f90
+++ b/puffin/lib/setup/checks.f90
@@ -16,7 +16,9 @@ use puffin_kinds, only: long, WP, IP
 use IO, only: tErrorLog_G, log_error
 use puffin_constants, only: pi, iX_CG, iY_CG, iZ2_CG, iPX_CG, iPY_CG, iDiffraction_CG, &
   iFocussing_CG, iOneD_CG
-use Globals, only: qRndFj_G, sSigFj_G, qRndEj_G, sSigEj_G, gExtEj_G, sStepSize, nSteps
+use Globals, only: qRndFj_G, sSigFj_G, qRndEj_G, sSigEj_G, gExtEj_G, sStepSize, nSteps, &
+                   qAveraged_G, sLambdarPerCell_G
+use averaging, only: getAvgUndAmps, qAvgPolarisationOK
 use particleFunctions, only: iTopHatDistribution_CG, gaussian
 use grids, only: getinttypes
 use ParallelSetUp, only: stopcode
@@ -89,6 +91,9 @@ subroutine CheckParameters(sLenEPulse,iNumElectrons,nbeams,&
   end do
 
   call stpFSampleLens(iNodes,sWigglerLength,sLengthOfElm,qSwitches(iOneD_CG),qOKL)
+
+  call chkAveraged(qSwitches(iOneD_CG), f_x, f_y, qOKL)
+  if (.NOT. qOKL) goto 1000
 
   if (qSimple) then
 
@@ -475,6 +480,44 @@ end subroutine checkRndEjLens
 
 
 
+!> Checks specific to the period-averaged mode (qAveraged).  f_x, f_y are the
+!> polarisation after calcScaling, which sets them from the undulator type.
+
+subroutine chkAveraged(qOneD, f_x, f_y, qOK)
+
+  logical, intent(in) :: qOneD
+  real(kind=wp), intent(in) :: f_x, f_y
+  logical, intent(out) :: qOK
+
+  real(kind=wp) :: cx, cy
+
+  qOK = .true.
+
+  if (.not. qAveraged_G) return
+
+  if (.not. qOneD) then
+    call log_error('Averaged mode (qAveraged) supports 1D only so far.', tErrorLog_G)
+    qOK = .false.
+  end if
+
+  call getAvgUndAmps("", f_x, f_y, cx, cy)
+
+  if (.not. qAvgPolarisationOK(cx, cy)) then
+    call log_error('Averaged mode (qAveraged) needs a helical or linearly '// &
+                   'polarised undulator: one field envelope cannot represent '// &
+                   'elliptical polarisation.', tErrorLog_G)
+    qOK = .false.
+  end if
+
+  if (sLambdarPerCell_G <= 0.0_wp) then
+    call log_error('lambdarPerCell must be > 0 in averaged mode.', tErrorLog_G)
+    qOK = .false.
+  end if
+
+end subroutine chkAveraged
+
+
+
 SUBROUTINE chkFSampleLens(iNodes,sWigglerLength,sLengthOfElm,rho,qOK)
 
 !                  ARGUMENTS
@@ -513,7 +556,10 @@ SUBROUTINE chkFSampleLens(iNodes,sWigglerLength,sLengthOfElm,rho,qOK)
       GOTO 1000
     END IF
 
-    IF (sLengthOfElm(iZ2_CG) > maxspcing) THEN
+!     Averaged mode stores an envelope rather than the carrier, so the mesh
+!     need not resolve the resonant wavelength - coarsening it is the point.
+
+    IF ((sLengthOfElm(iZ2_CG) > maxspcing) .and. (.not. qAveraged_G)) THEN
       CALL log_error("Length of field elements > 1/8th of resonant wavelength in z2.",tErrorLog_G)
       GOTO 1000
     END IF

--- a/puffin/lib/setup/setup_calcs.f90
+++ b/puffin/lib/setup/setup_calcs.f90
@@ -29,7 +29,9 @@ USE Globals, only: NX_G, NBX_G, NY_G, NBY_G, NZ2_G, NBZ2_G, ntrnds_G, ntrndsi_G,
   sKBeta_G, fx_G, fy_G, zUndType_G, kx_und_G, ky_und_G, sKBetaX_G, sKBetaY_G, sKBetaXSF_G, &
   sKBetaYSF_G, mf, diffStep, sStepSize, nSteps, sRedistLen_G, iRedistStp_G, tArrayE, tArrayA, &
   tArrayZ, ioutInfo_G, qElectronsEvolve_G, qFieldEvolve_G, qElectronFieldCoupling_G, &
-  qDiffraction_G, qFocussing_G, qDump_G, qResume_G, qMod_G, qOneD_G
+  qDiffraction_G, qFocussing_G, qDump_G, qResume_G, qMod_G, qOneD_G, qAveraged_G, &
+  sLambdarPerCell_G
+use averaging, only: getAvgSeedFactor
 USE simple_electron_gen, only: generate_simple_beam, shuntbeam
 USE gMPsFromDists, only: getmps
 use avwrite, only: getcurrnpts, linspace
@@ -868,7 +870,11 @@ subroutine calcSamples(sFieldModelLength, iNumNodes, sLengthOfElm, &
   integer(kind=ip) :: ib
 
 
-  dz2 = 4.0_WP * pi * frame%rho / real(nodesperlambda-1_IP,kind=wp)
+  if (qAveraged_G) then
+    dz2 = 4.0_WP * pi * frame%rho * sLambdarPerCell_G  ! envelope mesh, see averaging.f90
+  else
+    dz2 = 4.0_WP * pi * frame%rho / real(nodesperlambda-1_IP,kind=wp)
+  end if
 
   iNumNodes(iZ2_CG) = ceiling(sFieldModelLength(iZ2_CG) / dz2) + 1_IP
 
@@ -1058,7 +1064,11 @@ subroutine calcSamples(sFieldModelLength, iNumNodes, sLengthOfElm, &
 
   end if
 
-  dz2 = 4.0_WP * pi * frame%rho / real(nodesperlambda-1_IP,kind=wp)
+  if (qAveraged_G) then
+    dz2 = 4.0_WP * pi * frame%rho * sLambdarPerCell_G  ! envelope mesh, see averaging.f90
+  else
+    dz2 = 4.0_WP * pi * frame%rho / real(nodesperlambda-1_IP,kind=wp)
+  end if
 
   iNumNodes(iZ2_CG) = ceiling(sFieldModelLength(iZ2_CG) / dz2) + 1_IP
 
@@ -1469,6 +1479,7 @@ SUBROUTINE getSeed(NN,sig,cen,magx,magy,qFT,qRnd, &
                    oscy(:)
 
   REAL(KIND=WP) :: lx, ly, z2sl, z2el
+  REAL(KIND=WP) :: magxl, magyl
 
   INTEGER(KIND=IP) :: ind1, ind2, ind3, gind, nz2l
 
@@ -1563,8 +1574,31 @@ SUBROUTINE getSeed(NN,sig,cen,magx,magy,qFT,qRnd, &
 
 !     x and y polarized fields in z2
 
-  oscx = z2env * sin(fr * z2nds / (2.0_WP * rho) - ph_sh)! + 4.0_wp*(cos(10_wp * z2nds)))
-  oscy = z2env * cos(fr * z2nds / (2.0_WP * rho) - ph_sh)!+ 4.0_wp*(cos(10_wp * z2nds)))
+  if (qAveraged_G) then
+
+!     Averaged mode stores only the envelope of the resonant exp(-i z2/2rho)
+!     component.  Of A_perp = magx sin(psi) + i magy cos(psi) that is
+!     (i/2)(magx + magy) exp(-i psi); with psi' = psi - z2/2rho the carrier
+!     removed, i exp(-i psi') = sin(psi') + i cos(psi'), so the envelope has
+!     the same form as the resolved seed with fr -> fr - 1 and one common
+!     amplitude, scaled to the stored normalisation (see averaging.f90).
+!     The exp(+i psi) component is far outside the envelope band and dropped.
+
+    oscx = z2env * sin((fr - 1.0_wp) * z2nds / (2.0_WP * rho) - ph_sh)
+    oscy = z2env * cos((fr - 1.0_wp) * z2nds / (2.0_WP * rho) - ph_sh)
+
+    magxl = 0.5_wp * (magx + magy) * getAvgSeedFactor("", fx_G, fy_G)
+    magyl = magxl
+
+  else
+
+    oscx = z2env * sin(fr * z2nds / (2.0_WP * rho) - ph_sh)! + 4.0_wp*(cos(10_wp * z2nds)))
+    oscy = z2env * cos(fr * z2nds / (2.0_WP * rho) - ph_sh)!+ 4.0_wp*(cos(10_wp * z2nds)))
+
+    magxl = magx
+    magyl = magy
+
+  end if
 
 !     Full 3D field
 
@@ -1573,8 +1607,8 @@ SUBROUTINE getSeed(NN,sig,cen,magx,magy,qFT,qRnd, &
       do ind3 = 1,NN(iX_CG)
 
         gind = ind3 + NN(iX_CG)*(ind2-1) + NN(iX_CG)*NN(iY_CG)*(ind1-1)
-        xfield(gind) = magx * xenv(ind3) * yenv(ind2) * oscx(ind1)
-        yfield(gind) = magy * xenv(ind3) * yenv(ind2) * oscy(ind1)
+        xfield(gind) = magxl * xenv(ind3) * yenv(ind2) * oscx(ind1)
+        yfield(gind) = magyl * xenv(ind3) * yenv(ind2) * oscy(ind1)
 
       end do
     end do

--- a/puffin/lib/undulator.f90
+++ b/puffin/lib/undulator.f90
@@ -22,6 +22,7 @@ use RK4int, only: ac_rfield_in, ac_ifield_in, rk4par, allact_rk4_arrs, deallact_
 use write_adapter, only: writeim, qwriteq, iStep
 use ParaField, only: getlocalfieldindices, inner2outer, outer2inner, getinnode
 use GlobalTypes, only: tSimulationContext
+use averaging, only: getAvgUndAmps, qAvgPolarisationOK, getAvgBufferPqSq
 use AdapterGlobals, only: PopulateIntegrationStateFromGlobals, UpdateGlobalsFromIntegrationState, &
   PopulateUndulatorFromGlobals, UpdateGlobalsFromUndulator
 use Globals, only: qResume_G
@@ -78,6 +79,7 @@ contains
     logical :: qDWrDone
     integer :: error
     logical :: qResuming
+    real(kind=wp) :: cx, cy, pqSqBuff
 
   call Get_time(locTimeSt)
 
@@ -92,6 +94,30 @@ contains
 ! Populate per-element undulator parameters from globals set by initUndulator
 
   call PopulateUndulatorFromGlobals(ctx%und)
+
+! Averaged mode carries one field envelope, which is exact only for a helical
+! or linearly polarised undulator. Setup checks the main input file; this
+! catches a lattice file that switches polarisation module by module.
+! pqSqBuff is the quiver |pperp|^2 the field buffers must allow for, since in
+! averaged mode it is not in the stored pperp (see calcBuff) - zero otherwise.
+
+  pqSqBuff = 0.0_wp
+
+  if (ctx%flags%period_averaged) then
+
+    pqSqBuff = getAvgBufferPqSq(ctx%und)
+
+    call getAvgUndAmps(ctx%und%undulator_type, ctx%und%fx, ctx%und%fy, cx, cy)
+
+    if (.not. qAvgPolarisationOK(cx, cy)) then
+      if (tProcInfo_G%qRoot) print*, 'Averaged mode (qAveraged) needs a helical or ', &
+                                     'linearly polarised undulator - module ', iM, &
+                                     ' has ux, uy = ', cx, cy
+      call mpi_finalize(error)
+      stop
+    end if
+
+  end if
 
   qResuming = qResume_G
 
@@ -108,7 +134,11 @@ contains
 
     ctx%integration%start_step = 0_ip  ! ...TEMP...
 
-    if (.not. ctx%und%model_undulator_ends) call matchIn(szl, ctx%frame, ctx%und%n2col)
+!   In averaged mode pperp holds only its slow part, so the beam is not given
+!   the undulator's quiver momentum on entry (nor has it removed on exit).
+
+    if ((.not. ctx%und%model_undulator_ends) .and. (.not. ctx%flags%period_averaged)) &
+      call matchIn(szl, ctx%frame, ctx%und%n2col)
 
   end if
 
@@ -126,7 +156,7 @@ contains
   end if
 
 
-  call getLocalFieldIndices(ctx%integration%redistribution_length*2.0_wp, ctx%flags, ctx%frame)
+  call layoutField(ctx%integration%redistribution_length*2.0_wp)
 
 
   iSteps4Diff = nint(ctx%integration%diffraction_step_size / ctx%integration%step_size)
@@ -230,7 +260,7 @@ end if
             call getInNode(ctx%flags)
             ctx%flags%inner_xy_ok = .true.
           end if
-          call getLocalFieldIndices(ctx%integration%redistribution_length, ctx%flags, ctx%frame)
+          call layoutField(ctx%integration%redistribution_length)
           ctx%flags%parallel_arrays_ok = .true.
           call allact_rk4_arrs()
           ctx%flags%inner_xy_ok = .true.
@@ -357,7 +387,7 @@ end if
   if (mod(ctx%lattice%cumulative_steps, ctx%integration%redistribution_step) == 0) then
 
     call deallact_rk4_arrs()
-    call getLocalFieldIndices(ctx%integration%redistribution_length, ctx%flags, ctx%frame)
+    call layoutField(ctx%integration%redistribution_length)
     call allact_rk4_arrs()
 
   end if
@@ -376,7 +406,8 @@ end if
 
   end if
 
-  if (.not. ctx%und%model_undulator_ends) call matchOut(sZ, ctx%frame, ctx%und%n2col)
+  if ((.not. ctx%und%model_undulator_ends) .and. (.not. ctx%flags%period_averaged)) &
+    call matchOut(sZ, ctx%frame, ctx%und%n2col)
 
   call correctTrans()  ! correct transverse motion at undulator exit
 
@@ -389,6 +420,24 @@ end if
 
   call UpdateGlobalsFromIntegrationState(ctx%integration)
   call UpdateGlobalsFromUndulator(ctx%und)
+
+contains
+
+! Lay out the parallel field for the next stretch of integration. In averaged
+! mode the buffers must allow for the quiver |pperp|^2 that pperp no longer
+! holds; otherwise the call is exactly the unaveraged one.
+
+  subroutine layoutField(sdz)
+
+    real(kind=wp), intent(in) :: sdz
+
+    if (ctx%flags%period_averaged) then
+      call getLocalFieldIndices(sdz, ctx%flags, ctx%frame, pqSqBuff)
+    else
+      call getLocalFieldIndices(sdz, ctx%flags, ctx%frame)
+    end if
+
+  end subroutine layoutField
 
 end subroutine UndSection
 

--- a/puffin/lib/undulator/averaging.f90
+++ b/puffin/lib/undulator/averaging.f90
@@ -1,0 +1,333 @@
+! Copyright 2012-2018, University of Strathclyde
+! Authors: Lawrence T. Campbell
+! License: BSD-3-Clause
+
+!> @author
+!> Lawrence Campbell,
+!> University of Strathclyde,
+!> Glasgow, UK
+!> @brief
+!> Period-averaged (SVEA) electron-field coupling, for the opt-in averaged
+!> solver mode (qAveraged).
+!>
+!> Puffin normally resolves the radiation carrier on the z2 mesh and the
+!> undulator quiver in the electron equations.  In averaged mode the field
+!> arrays hold a slowly varying envelope instead,
+!>
+!>     A_perp = (u-/sqrt(fp)) Atilde exp(-i z2/2rho)  +  (u+/sqrt(fp)) conj(Atilde) exp(+i z2/2rho)
+!>
+!> and pperp holds only its slow part: the quiver is carried analytically and
+!> averaged over an undulator period.  The carrier sign is fixed by Puffin's
+!> own conventions - with bx = cx cos(zbar/2rho), by = cy sin(zbar/2rho) the
+!> quiver is
+!>
+!>     pperp_w = -alpha [ u+ exp(+i zbar/2rho) + u- exp(-i zbar/2rho) ],
+!>     u- = (cy + cx)/2,   u+ = (cy - cx)/2,
+!>
+!> and the resonant field component is the one at exp(-i z2/2rho).  (The
+!> seed Puffin builds for sA0_X = sA0_Y is exactly that helicity.)
+!>
+!> Averaging the coupling over a period turns the quiver into a single
+!> effective 'resonant momentum' per macroparticle,
+!>
+!>     ptilde_j = -alpha sqrt(fp) JJ_j exp(-i theta_j),
+!>     theta_j  = (zbar - z2_j) / 2rho,
+!>
+!> and the averaged system is the unaveraged one with pperp replaced by
+!> ptilde in BOTH places it couples to the field - the field source in
+!> getSource_* and the energy equation in dgamdz_f.  Using one array for both
+!> is what makes the averaged system conserve beam plus field energy exactly:
+!> alpha, fp and JJ cannot drift apart because they are only computed here.
+!>
+!> The normalisation by sqrt(fp), fp = (cx^2 + cy^2)/2, makes |Atilde|^2 the
+!> period-averaged |A_perp|^2, so the power diagnostics need no change.
+!>
+!> JJ comes from the 2 theta_w ripple in |pperp_w|^2 for a planar undulator:
+!> p2 ripples, so z2 carries a figure-of-eight excursion of phase amplitude
+!>
+!>     xi_j = (1 + eta p2_j)^3 aw^2 alpha^2 (cy^2 - cx^2)/2 / (4 eta gamma_r^2 Gamma_j^2),
+!>
+!> and expanding exp(i xi sin(2 theta_w)) in Bessel functions against the two
+!> quiver components leaves JJ = J0(xi) - (u+/u-) J1(xi).  For a helical
+!> undulator |pperp_w| is constant, xi = 0 and JJ = 1.  xi is evaluated per
+!> macroparticle: it goes as 1/Gamma^2, and taking it at the reference energy
+!> alone, as Genesis does, would put an error of ~0.2 (Gamma_j - 1) into the
+!> planar coupling.
+!>
+!> A single envelope is exact only when the two helicity components of the
+!> resonant field stay proportional: helical (u+ = 0) or linear (|u+| = |u-|).
+!> A general elliptical undulator needs two envelopes, and is rejected.
+
+module averaging
+
+use puffin_kinds, only: WP
+use puffin_constants, only: pi
+use GlobalTypes, only: tUndulator, tFELFrame
+use wigglerVar, only: getAlpha
+
+implicit none (type, external)
+private
+
+public :: tAvgCoupling, getAvgUndAmps, getAvgPolarisation, qAvgPolarisationOK, &
+          getAvgEnvelope, getAvgCoupling, avgJJ, getResonantMomentum, &
+          getAvgSeedFactor, getAvgBufferPqSq
+
+
+!> The period-averaged coupling at one zbar, common to every macroparticle.
+!> The per-particle part (JJ_j and the phase) is added by getResonantMomentum.
+
+type :: tAvgCoupling
+  real(kind=wp) :: amp      ! alpha sqrt(fp) - |ptilde| before JJ
+  real(kind=wp) :: xiCoef   ! xi_j = xiCoef (1 + eta p2_j)^3 / Gamma_j^2
+  real(kind=wp) :: uRatio   ! u+/u-
+  real(kind=wp) :: pqSq     ! period average of |pperp_w|^2 = alpha^2 fp, for getP2Avg
+  real(kind=wp) :: jjRef    ! JJ for the reference particle, for diagnostics
+end type tAvgCoupling
+
+
+contains
+
+!> On-axis amplitudes (cx, cy) of the undulator field in the main section,
+!> bx = cx cos(zbar/2rho), by = cy sin(zbar/2rho).  Mirrors the iUndMain_G
+!> branches of getBXfield/getBYfield at x = y = 0.  Takes the type and the
+!> polarisation scalars rather than a tUndulator so the seed setup, which runs
+!> before the lattice is built, can use it too.
+
+  subroutine getAvgUndAmps(undType, fx, fy, cx, cy)
+
+    character(*), intent(in) :: undType
+    real(kind=wp), intent(in) :: fx, fy
+    real(kind=wp), intent(out) :: cx, cy
+
+    select case (trim(undType))
+
+    case ("curved", "planepole")
+
+      cx = 0.0_wp
+      cy = 1.0_wp
+
+    case ("helical")
+
+      cx = 1.0_wp
+      cy = 1.0_wp
+
+    case default
+
+!     'puffin' elliptical undulator - variable polarisation
+
+      cx = fx
+      cy = fy
+
+    end select
+
+  end subroutine getAvgUndAmps
+
+
+!> Helicity weights of the quiver and the polarisation factor
+!> fp = (cx^2 + cy^2)/2 = u-^2 + u+^2, the period average of |pperp_w|^2 / alpha^2.
+
+  subroutine getAvgPolarisation(cx, cy, uMinus, uPlus, fp)
+
+    real(kind=wp), intent(in) :: cx, cy
+    real(kind=wp), intent(out) :: uMinus, uPlus, fp
+
+    uMinus = 0.5_wp * (cy + cx)
+    uPlus = 0.5_wp * (cy - cx)
+    fp = 0.5_wp * (cx**2 + cy**2)
+
+  end subroutine getAvgPolarisation
+
+
+!> Whether a single envelope represents the resonant field exactly - helical
+!> (u+ = 0) or linearly polarised (|u+| = |u-|).  u- = 0 is the opposite
+!> helicity, resonant with the exp(+i z2/2rho) carrier instead.
+
+  logical function qAvgPolarisationOK(cx, cy)
+
+    real(kind=wp), intent(in) :: cx, cy
+
+    real(kind=wp) :: uMinus, uPlus, fp, tol
+
+    call getAvgPolarisation(cx, cy, uMinus, uPlus, fp)
+
+    tol = 1.0e-12_wp * max(abs(uMinus), abs(uPlus), tiny(1.0_wp))
+
+    qAvgPolarisationOK = (abs(uMinus) > tol) .and. &
+                         ((abs(uPlus) <= tol) .or. &
+                          (abs(abs(uPlus) - abs(uMinus)) <= tol))
+
+  end function qAvgPolarisationOK
+
+
+!> Period-averaged envelope of the undulator field, 0 to 1.  In the main
+!> section it is 1; over the end ramps it follows the linear ramp of the by
+!> field in bfields.f90, which rises over 2 periods (8 pi rho).  The helical
+!> bx ramp has a slightly different shape - averaged mode uses the by ramp
+!> for both components, which is only a difference in how the coupling is
+!> switched on over those two periods.
+
+  real(kind=wp) function getAvgEnvelope(sZ, und, frame)
+
+    real(kind=wp), intent(in) :: sZ
+    type(tUndulator), intent(in) :: und
+    type(tFELFrame), intent(in) :: frame
+
+    real(kind=wp) :: rampLen
+
+    getAvgEnvelope = 1.0_wp
+
+    if (.not. und%model_undulator_ends) return
+
+    rampLen = 8.0_wp * pi * frame%rho
+
+    if (sZ <= und%z_start_undulator) then
+      getAvgEnvelope = sZ / rampLen
+    else if (sZ >= und%z_end_undulator) then
+      getAvgEnvelope = 1.0_wp - (sZ - und%z_end_undulator) / rampLen
+    end if
+
+    getAvgEnvelope = min(max(getAvgEnvelope, 0.0_wp), 1.0_wp)
+
+  end function getAvgEnvelope
+
+
+!> The period-averaged coupling at zbar = sZ.  alpha includes the taper (via
+!> getAlpha, on a local copy so nothing is mutated) and the end-ramp envelope.
+
+  subroutine getAvgCoupling(sZ, und, frame, cpl)
+
+    real(kind=wp), intent(in) :: sZ
+    type(tUndulator), intent(in) :: und
+    type(tFELFrame), intent(in) :: frame
+    type(tAvgCoupling), intent(out) :: cpl
+
+    type(tUndulator) :: undLocal
+    real(kind=wp) :: cx, cy, uMinus, uPlus, fp, alphaEff, onePlusEtaP2
+
+    undLocal = und
+    call getAlpha(sZ, undLocal)
+
+    alphaEff = undLocal%n2col * getAvgEnvelope(sZ, und, frame)
+
+    call getAvgUndAmps(und%undulator_type, und%fx, und%fy, cx, cy)
+    call getAvgPolarisation(cx, cy, uMinus, uPlus, fp)
+
+    cpl%amp = alphaEff * sqrt(fp)
+    cpl%uRatio = uPlus / uMinus
+    cpl%pqSq = alphaEff**2 * fp
+
+    cpl%xiCoef = frame%aw**2 * alphaEff**2 * 0.5_wp * (cy**2 - cx**2) &
+                 / (4.0_wp * frame%eta * frame%gamma_ref**2)
+
+!   Reference particle: Gamma = 1, no slow transverse momentum
+
+    onePlusEtaP2 = 1.0_wp / sqrt(1.0_wp - (1.0_wp + frame%aw**2 * cpl%pqSq) &
+                                          / frame%gamma_ref**2)
+
+    cpl%jjRef = avgJJ(cpl, onePlusEtaP2, 1.0_wp)
+
+  end subroutine getAvgCoupling
+
+
+!> JJ for a macroparticle with the given (1 + eta p2) and Gamma.
+
+  elemental real(kind=wp) function avgJJ(cpl, onePlusEtaP2, gam)
+
+    type(tAvgCoupling), intent(in) :: cpl
+    real(kind=wp), intent(in) :: onePlusEtaP2, gam
+
+    real(kind=wp) :: xi
+
+    xi = cpl%xiCoef * onePlusEtaP2**3 / gam**2
+
+    avgJJ = bessel_j0(xi) - cpl%uRatio * bessel_j1(xi)
+
+  end function avgJJ
+
+
+!> ptilde_j = -alpha sqrt(fp) JJ_j exp(-i theta_j), theta_j = (zbar - z2_j)/2rho,
+!> split into real and imaginary parts.  These stand in for spr, spi wherever
+!> the electrons couple to the field.  sp2 must already hold the averaged p2
+!> (getP2Avg).  Called from inside the !$OMP PARALLEL region in getrhs, so it
+!> is an orphaned !$OMP DO over private scalars, as getP2 is.  A helical
+!> undulator has xi = 0, JJ = 1, and skips the Bessel functions.
+
+  subroutine getResonantMomentum(sZ, sz2, sgam, sp2, eta, rho, cpl, sprRes, spiRes)
+
+    real(kind=wp), intent(in) :: sZ, eta, rho
+    real(kind=wp), contiguous, intent(in) :: sz2(:), sgam(:), sp2(:)
+    type(tAvgCoupling), intent(in) :: cpl
+    real(kind=wp), contiguous, intent(out) :: sprRes(:), spiRes(:)
+
+    integer :: i
+    real(kind=wp) :: inv2rho, theta, mag
+
+    inv2rho = 1.0_wp / (2.0_wp * rho)
+
+    if (cpl%xiCoef == 0.0_wp) then
+
+!$OMP DO PRIVATE(theta)
+      do i = 1, size(sz2)
+        theta = (sZ - sz2(i)) * inv2rho
+        sprRes(i) = -cpl%amp * cos(theta)
+        spiRes(i) = cpl%amp * sin(theta)
+      end do
+!$OMP END DO
+
+    else
+
+!$OMP DO PRIVATE(theta, mag)
+      do i = 1, size(sz2)
+        theta = (sZ - sz2(i)) * inv2rho
+        mag = cpl%amp * avgJJ(cpl, 1.0_wp + eta * sp2(i), sgam(i))
+        sprRes(i) = -mag * cos(theta)
+        spiRes(i) = mag * sin(theta)
+      end do
+!$OMP END DO
+
+    end if
+
+  end subroutine getResonantMomentum
+
+
+!> Upper bound over the module on the period-averaged quiver |pperp|^2, for
+!> sizing the parallel field buffers (calcBuff).  p2 grows with |pperp|^2, so
+!> taking the larger end of the linear taper, and ignoring the end ramps that
+!> only reduce it, over-estimates the slippage - which is the safe side.
+
+  real(kind=wp) function getAvgBufferPqSq(und)
+
+    type(tUndulator), intent(in) :: und
+
+    real(kind=wp) :: cx, cy, uMinus, uPlus, fp, alpha0, alpha1
+
+    call getAvgUndAmps(und%undulator_type, und%fx, und%fy, cx, cy)
+    call getAvgPolarisation(cx, cy, uMinus, uPlus, fp)
+
+    alpha0 = und%n2col_initial
+    alpha1 = und%n2col_initial + und%undulator_gradient * &
+                                 (und%z_end_undulator - und%z_start_undulator)
+
+    getAvgBufferPqSq = fp * max(alpha0**2, alpha1**2)
+
+  end function getAvgBufferPqSq
+
+
+!> Factor taking the exp(-i z2/2rho) component of a seed field to the stored
+!> envelope: Atilde = sqrt(fp)/u- * A+.
+
+  real(kind=wp) function getAvgSeedFactor(undType, fx, fy)
+
+    character(*), intent(in) :: undType
+    real(kind=wp), intent(in) :: fx, fy
+
+    real(kind=wp) :: cx, cy, uMinus, uPlus, fp
+
+    call getAvgUndAmps(undType, fx, fy, cx, cy)
+    call getAvgPolarisation(cx, cy, uMinus, uPlus, fp)
+
+    getAvgSeedFactor = sqrt(fp) / uMinus
+
+  end function getAvgSeedFactor
+
+end module averaging

--- a/puffin/lib/utilities/gamma_to_p2.f90
+++ b/puffin/lib/utilities/gamma_to_p2.f90
@@ -18,7 +18,7 @@ use puffin_kinds, only: WP, IP
 implicit none (type, external)
 private
 
-public :: getp2
+public :: getp2, getp2avg
 
 
 contains
@@ -113,6 +113,38 @@ contains
 !$OMP END DO
 
   end subroutine getP2
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+!> getP2 for the period-averaged mode, where px, py hold only the slow part
+!> of pperp.  The undulator quiver is added back through its period average
+!> pqSq = <|pperp_w|^2> (see getAvgCoupling) - the aw -> aw_rms substitution.
+!> The quiver's cross term with the slow part averages to zero over a period.
+!> Same cancellation-free form and same !$OMP DO structure as getP2.
+
+  subroutine getP2Avg(p2, gamma, px, py, eta, gamma0, aw, pqSq)
+
+  implicit none (type, external)
+
+    real(kind=wp), contiguous, intent(in) :: px(:), py(:), gamma(:)
+    real(kind=wp), intent(in) :: eta, gamma0, aw, pqSq
+
+    real(kind=wp), contiguous, intent(out) :: p2(:)
+
+    integer(kind=ip) :: i
+    real(kind=wp) :: u, rt
+
+!$OMP DO PRIVATE(u, rt)
+
+    do i = 1, size(p2, kind=ip)
+      u = ( 1.0_wp + aw**2*(px(i)**2 + py(i)**2 + pqSq) ) / (gamma0**2 * gamma(i)**2)
+      rt = sqrt(1.0_wp - u)
+      p2(i) = u / (eta * rt * (1.0_wp + rt))
+    end do
+
+!$OMP END DO
+
+  end subroutine getP2Avg
 
 
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -172,7 +172,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/expected/3D/clara_expected_integrated.h5"
 endif()
 
 add_pfunit_ctest (puffin_basic_tests
-  TEST_SOURCES testTests.pf testFFunctions.pf testLatticeElements.pf
+  TEST_SOURCES testTests.pf testFFunctions.pf testLatticeElements.pf testAveraging.pf
   LINK_LIBRARIES puffin_mpi
 )
 

--- a/test/testAveraging.pf
+++ b/test/testAveraging.pf
@@ -1,0 +1,468 @@
+!> Unit tests for the period-averaged (SVEA) mode - see averaging.f90.
+!!
+!! Two kinds of test.
+!!
+!! The first checks the averaging itself against brute force.  A single
+!! electron's exact quiver motion is followed over one undulator period, with
+!! p2 from the unaveraged getP2 so that the planar figure-of-eight excursion in
+!! z2 is included, and the period average of its coupling to the field - in
+!! the field source and in the energy equation - is compared with what the
+!! averaged model puts in its place.  That pins down JJ, the polarisation
+!! factor and the carrier sign independently of the solver.
+!!
+!! The second calls getrhs in averaged mode and checks that beam plus field
+!! energy is conserved to round-off in a single RHS evaluation.  The source and
+!! the energy equation share one coupling array by construction; this is the
+!! guard that stops them drifting apart (a mismatched JJ, alpha or phase
+!! factor between getSource_1D and dgamdz_f leaks energy while looking
+!! perfectly plausible).
+!!
+!! No MPI.
+
+module testAveraging
+
+  use pFUnit
+  use puffin_kinds
+  use puffin_constants, only: pi
+  use GlobalTypes, only: tUndulator, tFELFrame, tSimulationContext
+  use averaging, only: tAvgCoupling, getAvgUndAmps, getAvgPolarisation, qAvgPolarisationOK, &
+                       getAvgEnvelope, getAvgCoupling, avgJJ, getAvgSeedFactor
+  use gtop2, only: getP2, getP2Avg
+
+  implicit none
+
+contains
+
+  !> A frame and undulator loosely modelled on the 1D CLARA deck.  eta is set
+  !! so that a Gamma = 1 particle is exactly resonant (p2 = 1) in the averaged
+  !! model for this polarisation.
+  subroutine makeUnd(und, frame, undType, fx, fy)
+    type(tUndulator), intent(out) :: und
+    type(tFELFrame), intent(out) :: frame
+    character(*), intent(in) :: undType
+    real(kind=wp), intent(in) :: fx, fy
+
+    real(kind=wp) :: cx, cy, uMinus, uPlus, fp
+
+    frame%rho = 0.005_wp
+    frame%aw = 1.0121809_wp
+    frame%gamma_ref = 456.40_wp
+    frame%kappa = frame%aw / (2.0_wp * frame%rho * frame%gamma_ref)
+
+    und%undulator_type = undType
+    und%fx = fx
+    und%fy = fy
+    und%model_undulator_ends = .false.
+    und%z_start_undulator = 0.0_wp
+    und%z_end_undulator = 100.0_wp
+    und%n2col = 1.0_wp
+    und%n2col_initial = 1.0_wp
+    und%undulator_gradient = 0.0_wp
+    und%z_taper_start = 0.0_wp
+
+    call getAvgUndAmps(undType, fx, fy, cx, cy)
+    call getAvgPolarisation(cx, cy, uMinus, uPlus, fp)
+
+    frame%eta = 1.0_wp / sqrt(1.0_wp - (1.0_wp + frame%aw**2 * fp) &
+                                        / frame%gamma_ref**2) - 1.0_wp
+
+  end subroutine makeUnd
+
+
+  !> Trapezoidal average of f over the grid.
+  complex(kind=wp) function avgC(f)
+    complex(kind=wp), intent(in) :: f(0:)
+    integer :: n
+    n = ubound(f, 1)
+    avgC = (sum(f) - 0.5_wp * (f(0) + f(n))) / real(n, kind=wp)
+  end function avgC
+
+
+  !> Windowed average of f over the grid, weight sin^4(pi i/n).  Off
+  !! resonance the fast terms do not complete a whole number of cycles in any
+  !! fixed length, so a plain average leaks them in at O(1 - p2); the window's
+  !! sidelobes fall off fast enough that over several periods they vanish.
+  !! Brute force and model are averaged with the same weights, so the slow
+  !! drift of theta is common to both.
+  complex(kind=wp) function avgW(f)
+    complex(kind=wp), intent(in) :: f(0:)
+    real(kind=wp), allocatable :: wt(:)
+    integer :: n, i
+    n = ubound(f, 1)
+    allocate(wt(0:n))
+    do i = 0, n
+      wt(i) = sin(pi * real(i, kind=wp) / real(n, kind=wp))**4
+    end do
+    avgW = sum(wt * f) / sum(wt)
+  end function avgW
+
+
+  !> Period averages of the exact coupling, by brute force, and the averaged
+  !! model's prediction for the same quantities.
+  !!
+  !! srcPlus  = < w pperp exp(+i z2/2rho) >, the drive of the exp(-i z2/2rho)
+  !!            field component A+ (w = (1 + eta p2)/Gamma)
+  !! srcMinus = < w pperp exp(-i z2/2rho) >, the drive of the other helicity A-
+  !! eng      = < w Re(pperp conj(A_perp(z2))) >, the energy-equation coupling,
+  !!            for A_perp built from the envelope Atil as averaging.f90 defines
+  subroutine bruteForce(und, frame, gam, Atil, &
+                        srcPlus, srcMinus, eng, &
+                        srcPlusM, srcMinusM, engM, p2Mean, p2Model)
+    type(tUndulator), intent(in) :: und
+    type(tFELFrame), intent(in) :: frame
+    real(kind=wp), intent(in) :: gam
+    complex(kind=wp), intent(in) :: Atil
+    complex(kind=wp), intent(out) :: srcPlus, srcMinus, srcPlusM, srcMinusM
+    real(kind=wp), intent(out) :: eng, engM, p2Mean, p2Model
+
+    integer, parameter :: nPer = 8, n = 4000 * nPer
+    real(kind=wp), parameter :: z0 = 0.3_wp, z2start = 1.7_wp
+    real(kind=wp), allocatable, dimension(:) :: z, px, py, g, p2, z2, zc, w
+    complex(kind=wp), allocatable, dimension(:) :: pp, Aperp, ptil, f
+    real(kind=wp) :: cx, cy, uMinus, uPlus, fp, lamw, h, inv2rho, centre
+    type(tAvgCoupling) :: cpl
+    real(kind=wp) :: coup, wbar, p2m(1), gm(1), zero(1)
+    complex(kind=wp), parameter :: iu = (0.0_wp, 1.0_wp)
+    integer :: i
+
+    allocate(z(0:n), px(0:n), py(0:n), g(0:n), p2(0:n), z2(0:n), zc(0:n), w(0:n))
+    allocate(pp(0:n), Aperp(0:n), ptil(0:n), f(0:n))
+
+    call getAvgUndAmps(und%undulator_type, und%fx, und%fy, cx, cy)
+    call getAvgPolarisation(cx, cy, uMinus, uPlus, fp)
+
+    lamw = 4.0_wp * pi * frame%rho
+    h = nPer * lamw / real(n, kind=wp)
+    inv2rho = 1.0_wp / (2.0_wp * frame%rho)
+
+    do i = 0, n
+      z(i) = z0 + real(i, kind=wp) * h
+    end do
+
+!   Exact quiver: pperp = -alpha cy cos(zbar/2rho) + i alpha cx sin(zbar/2rho)
+
+    px = -und%n2col * cy * cos(z * inv2rho)
+    py = und%n2col * cx * sin(z * inv2rho)
+    pp = cmplx(px, py, kind=wp)
+    g = gam
+
+    call getP2(p2, g, px, py, frame%eta, frame%gamma_ref, frame%aw)
+
+!   z2 by trapezoidal integration of p2, then its guiding centre: the linear
+!   trend through the period mean, which is what the averaged model tracks.
+
+    z2(0) = z2start
+    do i = 1, n
+      z2(i) = z2(i-1) + 0.5_wp * h * (p2(i-1) + p2(i))
+    end do
+
+!   The z2 ripple is exactly periodic over whole undulator periods, so a plain
+!   average finds the guiding centre
+
+    p2Mean = (z2(n) - z2(0)) / (nPer * lamw)
+    centre = real(avgC(cmplx(z2 - p2Mean * (z - z0), 0.0_wp, kind=wp)), kind=wp)
+    zc = centre + p2Mean * (z - z0)
+
+    w = (1.0_wp + frame%eta * p2) / g
+
+!   The physical field seen at the particle's true position
+
+    Aperp = (uMinus / sqrt(fp)) * Atil * exp(-iu * z2 * inv2rho) &
+          + (uPlus / sqrt(fp)) * conjg(Atil) * exp(iu * z2 * inv2rho)
+
+    f = w * pp * exp(iu * z2 * inv2rho)
+    srcPlus = avgW(f)
+    f = w * pp * exp(-iu * z2 * inv2rho)
+    srcMinus = avgW(f)
+    f = cmplx(w * real(pp * conjg(Aperp), kind=wp), 0.0_wp, kind=wp)
+    eng = real(avgW(f), kind=wp)
+
+!   The averaged model: ptilde = -coup exp(-i (zbar - z2c)/2rho), with p2 and
+!   w from the period-averaged |pperp|^2
+
+    call getAvgCoupling(z0, und, frame, cpl)
+
+    gm = gam
+    zero = 0.0_wp
+    call getP2Avg(p2m, gm, zero, zero, frame%eta, frame%gamma_ref, frame%aw, cpl%pqSq)
+    p2Model = p2m(1)
+    wbar = (1.0_wp + frame%eta * p2Model) / gam
+
+!   JJ for this particle's own energy - the figure-of-eight goes as 1/Gamma^2
+
+    coup = cpl%amp * avgJJ(cpl, 1.0_wp + frame%eta * p2Model, gam)
+
+    ptil = -coup * exp(-iu * (z - zc) * inv2rho)
+
+    srcPlusM = (uMinus / sqrt(fp)) * wbar * avgW(ptil)
+    srcMinusM = (uPlus / sqrt(fp)) * wbar * conjg(avgW(ptil))
+    f = cmplx(wbar * real(ptil * conjg(Atil), kind=wp), 0.0_wp, kind=wp)
+    engM = real(avgW(f), kind=wp)
+
+  end subroutine bruteForce
+
+
+  !> Compare brute force and model for one undulator and energy.  The model
+  !! drops the O(eta) ripple in (1 + eta p2), so 1e-5 relative is as close as
+  !! it can be expected to get; any error in JJ, fp or the carrier sign is
+  !! O(1e-1) or O(1).
+  subroutine checkAgainstBruteForce(undType, fx, fy, gam)
+    character(*), intent(in) :: undType
+    real(kind=wp), intent(in) :: fx, fy, gam
+
+    type(tUndulator) :: und
+    type(tFELFrame) :: frame
+    complex(kind=wp) :: srcPlus, srcMinus, srcPlusM, srcMinusM
+    real(kind=wp) :: eng, engM, p2Mean, p2Model, scale
+    complex(kind=wp), parameter :: Atil = (0.3_wp, 0.7_wp)
+    real(kind=wp), parameter :: tol = 1.0e-5_wp
+
+    call makeUnd(und, frame, undType, fx, fy)
+    call bruteForce(und, frame, gam, Atil, srcPlus, srcMinus, eng, &
+                    srcPlusM, srcMinusM, engM, p2Mean, p2Model)
+
+    scale = abs(srcPlusM)
+
+    @assertEqual(real(srcPlusM, kind=wp), real(srcPlus, kind=wp), tol * scale)
+    @assertEqual(aimag(srcPlusM), aimag(srcPlus), tol * scale)
+    @assertEqual(real(srcMinusM, kind=wp), real(srcMinus, kind=wp), tol * scale)
+    @assertEqual(aimag(srcMinusM), aimag(srcMinus), tol * scale)
+    @assertEqual(engM, eng, tol * scale * abs(Atil))
+
+!   Period-averaged p2 against the true mean velocity.  They differ at second
+!   order in the |pperp|^2 ripple, ~1e-7 here - far below the rho = 5e-3
+!   scale on which it would detune the interaction.
+
+    @assertEqual(p2Mean, p2Model, 1.0e-5_wp)
+
+  end subroutine checkAgainstBruteForce
+
+
+  @test
+  subroutine testHelicalMatchesBruteForce()
+    call checkAgainstBruteForce("helical", 1.0_wp, 1.0_wp, 1.0_wp)
+    call checkAgainstBruteForce("helical", 1.0_wp, 1.0_wp, 1.004_wp)
+  end subroutine testHelicalMatchesBruteForce
+
+
+  @test
+  subroutine testPlanepoleMatchesBruteForce()
+    call checkAgainstBruteForce("planepole", 1.0_wp, 1.0_wp, 1.0_wp)
+    call checkAgainstBruteForce("planepole", 1.0_wp, 1.0_wp, 0.996_wp)
+  end subroutine testPlanepoleMatchesBruteForce
+
+
+  !> Linearly polarised along y, through the variably-polarised default type:
+  !! u+ = -u-, and the figure-of-eight has the opposite sign.
+  @test
+  subroutine testVerticalPlanarMatchesBruteForce()
+    call checkAgainstBruteForce("", 1.0_wp, 0.0_wp, 1.0_wp)
+  end subroutine testVerticalPlanarMatchesBruteForce
+
+
+  !> For planepole JJ must reduce to the textbook J0(xi) - J1(xi) with
+  !! xi = K^2/(4 + 2K^2), K the peak undulator parameter.  They differ only
+  !! through O(eta) terms in the exact resonance condition.
+  @test
+  subroutine testPlanarJJIsTextbook()
+    type(tUndulator) :: und
+    type(tFELFrame) :: frame
+    type(tAvgCoupling) :: cpl
+    real(kind=wp) :: xi
+
+    call makeUnd(und, frame, "planepole", 1.0_wp, 1.0_wp)
+    call getAvgCoupling(1.0_wp, und, frame, cpl)
+
+    xi = frame%aw**2 / (4.0_wp + 2.0_wp * frame%aw**2)
+
+    @assertEqual(bessel_j0(xi) - bessel_j1(xi), cpl%jjRef, 1.0e-4_wp)
+    @assertEqual(0.5_wp, cpl%pqSq, 1.0e-14_wp)
+    @assertEqual(sqrt(0.5_wp), cpl%amp, 1.0e-14_wp)
+
+    call makeUnd(und, frame, "helical", 1.0_wp, 1.0_wp)
+    call getAvgCoupling(1.0_wp, und, frame, cpl)
+
+    @assertEqual(1.0_wp, cpl%jjRef, 1.0e-14_wp)
+    @assertEqual(1.0_wp, cpl%amp, 1.0e-14_wp)
+    @assertEqual(0.0_wp, cpl%xiCoef, 0.0_wp)
+
+  end subroutine testPlanarJJIsTextbook
+
+
+  @test
+  subroutine testPolarisationSupport()
+    ! helical, planar in x, planar in y
+    @assertTrue(qAvgPolarisationOK(1.0_wp, 1.0_wp))
+    @assertTrue(qAvgPolarisationOK(0.0_wp, 1.0_wp))
+    @assertTrue(qAvgPolarisationOK(1.0_wp, 0.0_wp))
+    ! elliptical, and the opposite helicity
+    @assertFalse(qAvgPolarisationOK(0.6_wp, 0.8_wp))
+    @assertFalse(qAvgPolarisationOK(-1.0_wp, 1.0_wp))
+  end subroutine testPolarisationSupport
+
+
+  !> The seed factor takes the exp(-i z2/2rho) field component to the stored
+  !! envelope, whose |.|^2 is the period-averaged |A_perp|^2.
+  @test
+  subroutine testSeedFactor()
+    @assertEqual(1.0_wp, getAvgSeedFactor("helical", 1.0_wp, 1.0_wp), 1e-14_wp)
+    @assertEqual(sqrt(2.0_wp), getAvgSeedFactor("planepole", 1.0_wp, 1.0_wp), 1e-14_wp)
+  end subroutine testSeedFactor
+
+
+  !> Coupling ramps linearly over the 2-period end sections, as the by field does.
+  @test
+  subroutine testEnvelopeRamps()
+    type(tUndulator) :: und
+    type(tFELFrame) :: frame
+    real(kind=wp) :: ramp
+
+    call makeUnd(und, frame, "planepole", 1.0_wp, 1.0_wp)
+    ramp = 8.0_wp * pi * frame%rho
+
+    @assertEqual(1.0_wp, getAvgEnvelope(0.01_wp, und, frame), 1e-14_wp)
+
+    und%model_undulator_ends = .true.
+    und%z_start_undulator = ramp
+    und%z_end_undulator = 1.0_wp
+
+    @assertEqual(0.25_wp, getAvgEnvelope(0.25_wp * ramp, und, frame), 1e-14_wp)
+    @assertEqual(1.0_wp, getAvgEnvelope(0.5_wp, und, frame), 1e-14_wp)
+    @assertEqual(0.75_wp, getAvgEnvelope(1.0_wp + 0.25_wp * ramp, und, frame), 1e-14_wp)
+    @assertEqual(0.0_wp, getAvgEnvelope(1.0_wp + 2.0_wp * ramp, und, frame), 1e-14_wp)
+
+  end subroutine testEnvelopeRamps
+
+
+  !> One RHS evaluation of the averaged 1D system, with the real getrhs.  In
+  !! scaled units the field energy is sum_nodes |A|^2 dV3 and the beam energy
+  !! sum_j chi_j Gamma_j / (2 rho), so
+  !!
+  !!     sum_nodes (Ar dAr/dz + Ai dAi/dz) dV3 + sum_j chi_j dGamma_j/dz / (2 rho) = 0
+  !!
+  !! holds exactly for the discrete system: linear interpolation and linear
+  !! deposition share their weights, and the source and the energy equation
+  !! share ptilde.
+  subroutine checkRhsEnergyBalance(undType, fx, fy, grad, qEnds, sZ)
+
+    use Globals, only: sLengthOfElmX_G, sLengthOfElmY_G, sLengthOfElmZ2_G, NX_G, NY_G, &
+                       NZ2_G, nspinDX, nspinDY, fieldMesh, iTemporal, qElectronsEvolve_G, &
+                       qFieldEvolve_G, qElectronFieldCoupling_G, iNumberElectrons_G, &
+                       procelectrons_G, s_chi_bar_G, dadz_w
+    use ParaField, only: fz2, bz2, tTransInfo_G
+    use rhs, only: getrhs
+
+    character(*), intent(in) :: undType
+    real(kind=wp), intent(in) :: fx, fy, grad, sZ
+    logical, intent(in) :: qEnds
+
+    type(tSimulationContext) :: ctx
+    integer, parameter :: ne = 7, nz = 16
+    real(kind=wp) :: sAr(nz), sAi(nz), dAr(nz), dAi(nz)
+    real(kind=wp), dimension(ne) :: sx, sy, sz2, spr, spi, sgam, &
+                                    sdx, sdy, sdz2, sdpr, sdpi, sdgam
+    real(kind=wp) :: dz2v, fieldRate, beamRate
+    logical :: qOK
+    integer :: j
+
+    call makeUnd(ctx%und, ctx%frame, undType, fx, fy)
+    ctx%und%undulator_gradient = grad
+    ctx%und%model_undulator_ends = qEnds
+    if (qEnds) then
+      ctx%und%z_start_undulator = 8.0_wp * pi * ctx%frame%rho
+      ctx%und%z_end_undulator = 1.0_wp
+    end if
+
+    ctx%flags%period_averaged = .true.
+    ctx%flags%parallel_arrays_ok = .true.
+    ctx%flags%inner_xy_ok = .true.
+
+!   A 1D envelope mesh 1.5 resonant wavelengths per cell
+
+    dz2v = 1.5_wp * 4.0_wp * pi * ctx%frame%rho
+
+    sLengthOfElmX_G = 1.0_wp
+    sLengthOfElmY_G = 1.0_wp
+    sLengthOfElmZ2_G = dz2v
+    NX_G = 1
+    NY_G = 1
+    NZ2_G = nz
+    nspinDX = 1
+    nspinDY = 1
+    fieldMesh = iTemporal
+    tTransInfo_G%qOneD = .true.
+    fz2 = 1
+    bz2 = nz
+
+    qElectronsEvolve_G = .true.
+    qFieldEvolve_G = .true.
+    qElectronFieldCoupling_G = .true.
+
+    iNumberElectrons_G = ne
+    allocate(procelectrons_G(1), s_chi_bar_G(ne), dadz_w(ne))
+    procelectrons_G(1) = ne
+
+    do j = 1, ne
+      s_chi_bar_G(j) = 0.8_wp + 0.05_wp * j
+      sz2(j) = dz2v * (0.37_wp + 1.9_wp * j)
+      sgam(j) = 1.0_wp + 0.01_wp * sin(real(j, kind=wp))
+      spr(j) = 0.01_wp * cos(real(j, kind=wp))
+      spi(j) = -0.02_wp * sin(real(j, kind=wp))
+    end do
+
+    sx = 0.0_wp
+    sy = 0.0_wp
+
+    do j = 1, nz
+      sAr(j) = 0.1_wp * cos(0.7_wp * j)
+      sAi(j) = 0.1_wp * sin(0.3_wp * j + 1.0_wp)
+    end do
+
+    dAr = 0.0_wp
+    dAi = 0.0_wp
+    sdx = 0.0_wp; sdy = 0.0_wp; sdz2 = 0.0_wp
+    sdpr = 0.0_wp; sdpi = 0.0_wp; sdgam = 0.0_wp
+
+    call getrhs(sZ, sAr, sAi, sx, sy, sz2, spr, spi, sgam, &
+                sdx, sdy, sdz2, sdpr, sdpi, sdgam, dAr, dAi, qOK, ctx)
+
+    @assertTrue(qOK)
+
+    fieldRate = sum(sAr * dAr + sAi * dAi) * dz2v
+    beamRate = sum(s_chi_bar_G * sdgam) / (2.0_wp * ctx%frame%rho)
+
+!   Non-trivial, and balanced to round-off
+
+    @assertTrue(abs(fieldRate) > 1.0e-4_wp)
+    @assertEqual(0.0_wp, fieldRate + beamRate, 1.0e-13_wp * (abs(fieldRate) + abs(beamRate)))
+
+!   pperp holds only its slow part, and in 1D nothing drives it
+
+    @assertEqual(0.0_wp, maxval(abs(sdpr)), 0.0_wp)
+    @assertEqual(0.0_wp, maxval(abs(sdpi)), 0.0_wp)
+
+    deallocate(procelectrons_G, s_chi_bar_G, dadz_w)
+
+  end subroutine checkRhsEnergyBalance
+
+
+  @test
+  subroutine testRhsConservesEnergyHelical()
+    call checkRhsEnergyBalance("helical", 1.0_wp, 1.0_wp, 0.0_wp, .false., 0.37_wp)
+  end subroutine testRhsConservesEnergyHelical
+
+
+  @test
+  subroutine testRhsConservesEnergyPlanepole()
+    call checkRhsEnergyBalance("planepole", 1.0_wp, 1.0_wp, 0.0_wp, .false., 0.37_wp)
+  end subroutine testRhsConservesEnergyPlanepole
+
+
+  !> Taper and end ramp change alpha - it has to change in both equations at once.
+  @test
+  subroutine testRhsConservesEnergyTaperedRamp()
+    call checkRhsEnergyBalance("planepole", 1.0_wp, 1.0_wp, -0.05_wp, .true., 0.05_wp)
+    call checkRhsEnergyBalance("planepole", 1.0_wp, 1.0_wp, -0.05_wp, .true., 0.6_wp)
+  end subroutine testRhsConservesEnergyTaperedRamp
+
+end module testAveraging


### PR DESCRIPTION
Adds `qAveraged`, an opt-in period-averaged (SVEA) solver mode, in 1D.

Puffin resolves the radiation carrier on the z2 mesh, which locks the mesh spacing and the step size together: z2 must sample the carrier at ~12 nodes per resonant wavelength, resonant particles advect at `p2 = 1`, and the step is then limited by macroparticles crossing cells. In averaged mode the field arrays hold a slowly varying envelope about the carrier instead, and the electron equations are averaged over an undulator period with the quiver carried analytically, so the mesh can coarsen by an order of magnitude (`lambdarPerCell`) and the step with it.

**The mode is opt-in and the default path is byte-identical to `dev`** — verified by running 1D helical and planepole decks against a pristine `dev` build and comparing `/aperp` and `/power` byte for byte. All four `ctest` suites and 20 unit tests pass.

## How it is built

z2 stays the macroparticle coordinate and the ponderomotive phase is computed on the fly, so the parallel decomposition, buffer logic, node indexing, HDF5 write chain and diagnostics are untouched. The whole coupling is one per-particle resonant momentum

    ptilde_j = -alpha sqrt(fp) JJ_j exp(-i theta_j),   theta_j = (zbar - z2_j)/2rho

passed in place of `pperp` to **both** `getSource_*` and `dgamdz_f`. Sharing one array is what makes the averaged system conserve beam plus field energy exactly — alpha, the polarisation factor and JJ cannot drift apart, because they are computed in one place. `JJ` is evaluated per macroparticle, since the figure-of-eight amplitude goes as `1/Gamma^2` and taking it at the reference energy alone costs ~0.2 (Gamma − 1) in the planar coupling. The envelope is normalised so `|Atilde|^2` is the period average of `|A_perp|^2`, so power diagnostics need no change. The carrier is `exp(-i z2/2rho)`, fixed by Puffin's own helicity.

New module `puffin/lib/undulator/averaging.f90`; new input `lambdarPerCell`; equations and inputs documented in `doc/manual.tex`.

## Validation

Harness and full numbers in `benchmark/averaged/` (`run_compare.py` reproduces any row). Seeded 1D CLARA-like deck, 60 periods (~3.8 gain lengths). One step per undulator period is enough — 1, 2 and 4 steps agree to ~1e-6 — and at 1.5 s that is **9.3x faster** than the unaveraged solver at the deck's own settings (13.8 s).

Power at the final write, averaged over unaveraged:

| nodesPerLambdar | 12 | 24 | 48 | 96 |
| --- | --- | --- | --- | --- |
| helical | 1.086 | 1.013 | 0.997 | 0.994 |
| planepole | 1.065 | 0.981 | 0.962 | 0.958 |

Two results worth reviewers' attention:

**The unaveraged solver's default mesh is the less accurate of the two.** It converges at second order in the mesh, and at `nodesPerLambdar = 12` it is ~9% low: linear deposition and linear interpolation each attenuate a carrier sampled at 11 cells per wavelength by `sinc^2(pi/11)`, weakening the coupling ~5%. The step scans in `benchmark/convergence` could not see this, because they held the mesh fixed and measured against a finer step on the same mesh. Holding the mesh and halving the step changes planepole power by 4e-6, so these sequences really are mesh-limited.

**Most of the planar gap is harmonic radiation the mode cannot carry.** `/power` sums every frequency the mesh resolves; a planar undulator radiates at the odd harmonics (1.72% of power in the 3rd and 0.29% in the 5th at aw = 1.012; 0.12% and 0.002% at aw = 0.5; even harmonics at leakage level, as expected on axis in 1D), while the averaged mode carries one band. Comparing the fundamental band alone, helical is 0.63% low and planepole 1.67%, of which ~0.55% in both is a known omission — the radiation-driven transverse momentum `eta p2 A/kappa^2` in `dppdz`; zeroing that term in the unaveraged solver closes helical to ~0.07%. Planepole keeps ~1% that helical does not, flat in aw, which is documented rather than explained (UKFELs/Puffin#130, UKFELs/Puffin#129).

`test/testAveraging.pf` checks the averaging against brute force — a single electron's exact quiver, figure-of-eight excursion included, windowed over several periods and compared with what the model puts in its place, to ~5e-7 — and checks beam plus field energy balancing through the real `getrhs` to 1e-13, including under taper and in an end ramp.

## Scope

1D only, and helical or linearly polarised undulators only (a general elliptical undulator needs two envelopes); both are rejected at setup. Inside the mode you lose coherent spontaneous emission from sharp current gradients, bandwidth beyond roughly ±1/(2 `lambdarPerCell`) of the resonant frequency, harmonics, and far-from-resonance particles — which includes the two-colour and strong-taper decks. Undulator ends, when modelled, only ramp the coupling.

`calcBuff` needs an exact field-buffer bound for coarse envelope meshes, but takes it only in averaged mode: applying it generally changes the parallel layout and so the summation order, enough to miss the taper suite's 1e-10 golden by 1.7e-10 (UKFELs/Puffin#128).

## Follow-ups

`AVERAGED_MODE_ROADMAP.md` (second commit) records the programme of work: 3D, multiple field arrays for elliptical polarisation and harmonic bands (both much easier after UKFELs/Puffin#107), periodic-mesh and restart compatibility, dump metadata and viz support, and closing out the accuracy map. Open issues: UKFELs/Puffin#128, UKFELs/Puffin#129, UKFELs/Puffin#130.

## Testing

```
cmake -B build -DENABLE_TESTING=ON -DCMAKE_BUILD_TYPE=Debug ... -DPFUNIT_DIR=...
make -j8 -C build/
OMP_NUM_THREADS=1 ctest --output-on-failure --test-dir build/ -LE slow
cd benchmark/averaged && python3 run_compare.py helical
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
